### PR TITLE
get mode before using it to get municipality in default page controller

### DIFF
--- a/src/main/resources/site/pages/default/default.es6
+++ b/src/main/resources/site/pages/default/default.es6
@@ -39,6 +39,7 @@ const view = resolve('default.html')
 exports.get = function(req) {
   const ts = new Date().getTime()
   const page = getContent()
+  const mode = pageMode(req, page)
   const isFragment = page.type === 'portal:fragment'
   let regions = null
   if (isFragment) {
@@ -87,7 +88,6 @@ exports.get = function(req) {
   }
 
   const bodyClasses = []
-  const mode = pageMode(req, page)
   if (mode !== 'map' && config && config.bkg_color === 'grey') {
     bodyClasses.push('bkg-grey')
   }


### PR DESCRIPTION
Fixes bug where municipality-alerts did not show because municipality was always undefined in default page controller

MIMIR-250