### PR TITLE
MIMIR-206 handle error in tbml queries

### DIFF
--- a/src/main/resources/lib/tbml/tbml.ts
+++ b/src/main/resources/lib/tbml/tbml.ts
@@ -1,4 +1,4 @@
-import { HttpLibrary } from 'enonic-types/lib/http'
+import { HttpLibrary, HttpResponse } from 'enonic-types/lib/http'
 import { TbmlData, XmlParser } from '../types/xmlParser'
 const xmlParser: XmlParser = __.newBean('no.ssb.xp.xmlparser.XmlParser')
 const http: HttpLibrary = __non_webpack_require__( '/lib/http-client')
@@ -6,17 +6,18 @@ const http: HttpLibrary = __non_webpack_require__( '/lib/http-client')
 export function fetch(url: string): string {
   let result: string = '<tbml></tbml>'
 
-  try {
-    const body: string | null = http.request({
-      url
-    }).body
+  const response: HttpResponse = http.request({
+    url
+  })
+  const {
+    body,
+    status
+  } = response
 
-    if (body) {
-      result = body
-    }
-  } catch (e) {
-    log.error('Failed fetching ')
-    log.error(e)
+  if (status === 200 && body) {
+    result = body
+  } else {
+    throw new Error( `Failed with status ${status} while fetching tbml data from ${url}`)
   }
 
   return result


### PR DESCRIPTION
MIMIR-206
Throw an error in the tbml fetch method if the response status is not 200,
and let the dataquery update method handle the error however it sees fit,
instead of just swallowing the error and failing silently