### PR TITLE
replace nbsp with space on ingress in default page

### DIFF
--- a/src/main/resources/site/pages/default/default.es6
+++ b/src/main/resources/site/pages/default/default.es6
@@ -52,7 +52,7 @@ exports.get = function(req) {
 
   const glossary = glossaryLib.process(page.data.ingress, regions)
   const ingress = processHtml({
-    value: page.data.ingress
+    value: page.data.ingress.replace(/&nbsp;/g, ' ')
   })
   const showIngress = ingress && page.type === 'mimir:page'
 


### PR DESCRIPTION
MIMIR-307
react4xp crashes if there are any nbsp in the html from thymeleaf and
we need to replace them with actual spaces. This is only needed in parts,
layouts, and pages where we use both utext from html area, and react4xp components