### PR TITLE
Fix keyfigures not showing values for old municipalitycodes

### DIFF
--- a/src/main/resources/lib/ssb/keyFigure.ts
+++ b/src/main/resources/lib/ssb/keyFigure.ts
@@ -88,7 +88,7 @@ export function parseKeyFigure(keyFigure: Content<KeyFigure>, municipality?: Mun
             // get value and label from json-stat data, filtering on municipality
             let municipalData: MunicipalData | null = getDataFromMunicipalityCode(ds, municipality.code, yAxisLabel, filterTarget)
             // not all municipals have data, so if its missing, try the old one
-            if ((!municipalData || municipalData.value === null) && municipality.changes) {
+            if ((!municipalData || (municipalData.value === null ||municipalData.value === 0)) && municipality.changes) {
               municipalData = getDataFromMunicipalityCode(ds, municipality.changes[0].oldCode, yAxisLabel, filterTarget)
             }
             if (municipalData && municipalData.value !== null) {


### PR DESCRIPTION
- Add check for if value is 0

The values from statbank does not identify the difference of a valid 0 value, and a 0 meaning undefined or null. Both is 0.

Thats why we need to treat 0 as a possible null and do additional checks.