### PR TITLE
MIMIR-321 searchable text

### DIFF
--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -70,7 +70,6 @@
     >
       <div data-th-if="${region.showGreyTriangle}" class="grey-triangle"/>
       <div
-        class="searchabletext"
         data-th-classappend="${region.view == 'full' ? 'container-fluid p-0' : region.view == 'card' ? 'border-top-green container' : 'container'}"
       >
         <h2 data-th-if="${region.hideTitle && region.title}" class="sr-only sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
@@ -85,7 +84,7 @@
         </div>
       </div>
     </div>
-    <div data-th-if="${mainRegionComponents}" data-portal-region="main" class="searchabletext">
+    <div data-th-if="${mainRegionComponents}" data-portal-region="main">
       <div data-th-each="component : ${mainRegionComponents}" data-th-remove="tag">
         <div data-portal-component="${component.path}" data-th-remove="tag" ></div>
       </div>

--- a/src/main/resources/site/parts/banner/banner.html
+++ b/src/main/resources/site/parts/banner/banner.html
@@ -1,5 +1,5 @@
 <section
-  class="xp-part part-banner position-relative clearfix opacity-0 col-12"
+  class="xp-part part-banner position-relative clearfix opacity-0 col-12 searchabletext"
   data-th-classappend="${pageType._selected} == 'faktaside' ? 'factpage-banner' : ''">
 
   <img data-th-if="${bannerImage}"

--- a/src/main/resources/site/processors/searchableText.es6
+++ b/src/main/resources/site/processors/searchableText.es6
@@ -1,0 +1,6 @@
+exports.responseProcessor = function(req, res) {
+  if (res.status === 200 && res.body) {
+    res.body = res.body.replace(/<section data-portal-component-type="text">/g, '<section class="searchabletext" data-portal-component-type="text">')
+  }
+  return res
+}

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -246,4 +246,7 @@
       <match>type:'portal:fragment'</match>
     </mapping>
   </mappings>
+  <processors>
+    <response-processor name="searchableText" order="10"/>  
+  </processors>
 </site>


### PR DESCRIPTION
remove searchable text from all regions and add it to banner and text parts only. Since we're not controlling text parts I had to do it in postprocessing instead.