### PR TITLE
Mimir 483 fikse duplikate kommuner klassliste

### DIFF
--- a/src/main/resources/lib/klass/municipalities.ts
+++ b/src/main/resources/lib/klass/municipalities.ts
@@ -184,7 +184,7 @@ function changesWithMunicipalityCode(municipalityCode: string): Array<Municipali
   const changeList: Array<MunicipalityChange> = getMunicipalityChanges().codeChanges
   const changes: Array<MunicipalityChange> = changeList.filter( (change) => {
     return (change.oldCode === municipalityCode || change.newCode === municipalityCode) &&
-        change.oldName === change.newName
+        change.oldName === removeCountyFromMunicipalityName(change.newName)
   })
   return changes
 }
@@ -197,6 +197,10 @@ function getMunicipalityChanges(): MunicipalityChangeList {
   return body ? JSON.parse(body) : {
     codes: []
   }
+}
+
+export function removeCountyFromMunicipalityName(municiaplityName: string): string {
+	return municiaplityName.split('(')[0].trim()
 }
 
 export interface MunicipalityChangeList {

--- a/src/main/resources/lib/klass/municipalities.ts
+++ b/src/main/resources/lib/klass/municipalities.ts
@@ -200,7 +200,7 @@ function getMunicipalityChanges(): MunicipalityChangeList {
 }
 
 export function removeCountyFromMunicipalityName(municiaplityName: string): string {
-	return municiaplityName.split('(')[0].trim()
+  return municiaplityName.split('(')[0].trim()
 }
 
 export interface MunicipalityChangeList {

--- a/src/main/resources/lib/klass/municipalities.ts
+++ b/src/main/resources/lib/klass/municipalities.ts
@@ -184,7 +184,7 @@ function changesWithMunicipalityCode(municipalityCode: string): Array<Municipali
   const changeList: Array<MunicipalityChange> = getMunicipalityChanges().codeChanges
   const changes: Array<MunicipalityChange> = changeList.filter( (change) => {
     return (change.oldCode === municipalityCode || change.newCode === municipalityCode) &&
-        change.oldName === removeCountyFromMunicipalityName(change.newName)
+        removeCountyFromMunicipalityName(change.oldName) === removeCountyFromMunicipalityName(change.newName)
   })
   return changes
 }

--- a/src/main/resources/site/parts/banner/banner.es6
+++ b/src/main/resources/site/parts/banner/banner.es6
@@ -46,7 +46,7 @@ function renderPart(req) {
       id: part.config.image,
       scale: 'block(1400,400)'
     }) : undefined,
-	municipalityTitle : municipality ? municipalityName + ' (' + municipality.county.name+')' : undefined,
+    municipalityTitle: municipality ? municipalityName + ' (' + municipality.county.name + ')' : undefined,
     pageType,
     factsAbout
   }

--- a/src/main/resources/site/parts/banner/banner.es6
+++ b/src/main/resources/site/parts/banner/banner.es6
@@ -7,7 +7,7 @@ const {
   render
 } = __non_webpack_require__( '/lib/thymeleaf')
 const {
-  getMunicipality
+  getMunicipality, removeCountyFromMunicipalityName
 } = __non_webpack_require__( '/lib/klass/municipalities')
 const {
   getImageCaption
@@ -36,6 +36,8 @@ function renderPart(req) {
   const factsAbout = i18nLib.localize({
     key: 'factsAbout'
   })
+  const municipality = pageType._selected === 'kommunefakta' ? getMunicipality(req) : undefined
+  const municipalityName = municipality ? removeCountyFromMunicipalityName(municipality.displayName) : undefined
 
   const model = {
     pageDisplayName: page.displayName,
@@ -44,7 +46,7 @@ function renderPart(req) {
       id: part.config.image,
       scale: 'block(1400,400)'
     }) : undefined,
-    municipality: pageType._selected === 'kommunefakta' ? getMunicipality(req) : undefined,
+	municipalityTitle : municipality ? municipalityName + ' (' + municipality.county.name+')' : undefined,
     pageType,
     factsAbout
   }

--- a/src/main/resources/site/parts/banner/banner.html
+++ b/src/main/resources/site/parts/banner/banner.html
@@ -13,8 +13,8 @@
       <div data-th-if="${pageType._selected == 'kommunefakta'}" class="col-12">
         <div class="subtitle roboto-bold position-relative" data-th-text="${pageDisplayName}">Kommunefakta</div>
         <h1 class="mt-0 pt-0 position-relative"
-            data-th-if="${municipality}"
-            data-th-text="${municipality.displayName} +' (' + ${municipality.county.name} +')'">Navn på kommune</h1>
+            data-th-if="${municipalityTitle}"
+            data-th-text="${municipalityTitle}">Navn på kommune</h1>
       </div>
 
       <div data-th-if="${pageType._selected == 'faktaside'}" class="col-12">


### PR DESCRIPTION
Våler og Herøy henter nå data fra gamle kommunenr, og tittelen i banneren viser nå ikke dobbelt opp med fylkesnavn.