### PR TITLE
MIMIR-487 Fetch contacts from Statistikkregisteret

### DIFF
--- a/docs/StatReg.md
+++ b/docs/StatReg.md
@@ -1,7 +1,10 @@
 # Saving data from Statistikkregisteret in Content Studio
 
-## Goal
+### Goal
 To fetch data from statistikkregisteret and saving it in Content Studio. Uses [MIMIR XP Repo](MimirXPRepo.md).
+
+### Config
+- Requires `ssb.statreg.baseUrl` (picked up from mimir-config) - which points to the URL of the statreg API. 
 
 ### StatReg Repo
 - Uses repo `no.ssb.statreg` in `master` branch.


### PR DESCRIPTION
#### Goals
- Contacts are fetched from statreg and stored under `no.ssb.statreg` at `/contacts`. 
- Provides `getContactsFromRepo` utility interface that can be used to pick contacts from the mount point (f.eks. for use in an XP Part or customSelector)

#### Also,
- Provides an easy mechanism to mount similar content in the future (f.eks. `/publications` or `/statistics`) using the `configureNode(<mount-point-name>, <fetchFunction>)` interface. 
- In the simplest of scenarios (where the whole content is mounted at the topmost level in the `no.ssb.statreg` repo), all that is required is an additional line for the fetcher function. The following snippet shows saving publications, f.eks. -- 

   ```javascript
   import { fetchContacts } from './statreg/contacts'
   import { fetchStatistics } from './statreg/statistics'

   const STATREG_NODES = [
     configureNode('/contacts', fetchContacts),

     // add new mount points below, f.eks.
     configureNode('/statistics', fetchStatistics)  
   ]
   ```

- All StatReg content stored under `no.ssb.statreg` can be accessed via `{node}.content` where the `node` itself can be fetched using either the `getStatRegNode(<key>)` or the even more generic `getNode<T>(repo, branch, key)` interface from `/lib/repo/common.ts`. 

#### Miscellaneous
- Utility function `ensureArray(candidate)` which checks `candidate` and always returns an array - en empty array if candidate has a non-truthy value. Can replace `candidate && util.data.forceArray(candidate)` expressions. In the future, old code could be replaced using a code-mod.
- Polyfill-s for java -> javascript objects returned from nashorn -- `String::includes`. have also included polyfill-s for `Array::find`, `Array::includes` if one does not wish to use _ramda_ library.