### PR TITLE
MIMIR-617 : Fix axes title overlapping with labels

### DIFF
--- a/src/main/resources/lib/highcharts/config.es6
+++ b/src/main/resources/lib/highcharts/config.es6
@@ -166,7 +166,13 @@ export const createConfig = (highchartData, displayName) => ({
       align: 'high',
       offset: 0,
       rotation: 0,
-      y: 30
+      y: -15
+    },
+    xAxis: {
+      text: highchartData.xAxisTitle || '',
+      align: 'high',
+      offset: 0,
+      x: -5
     },
     type: highchartData.yAxisType || 'linear'
   },

--- a/src/main/resources/lib/highcharts/config.es6
+++ b/src/main/resources/lib/highcharts/config.es6
@@ -171,8 +171,7 @@ export const createConfig = (highchartData, displayName) => ({
     xAxis: {
       text: highchartData.xAxisTitle || '',
       align: 'high',
-      offset: 0,
-      x: -5
+      offset: 0
     },
     type: highchartData.yAxisType || 'linear'
   },

--- a/src/main/resources/lib/highcharts/config.es6
+++ b/src/main/resources/lib/highcharts/config.es6
@@ -179,11 +179,14 @@ export const createConfig = (highchartData, displayName) => ({
       text: highchartData.yAxisTitle || '',
       ...Y_AXIS_TITLE_POSITION
     },
-    xAxis: {
+    type: highchartData.yAxisType || 'linear'
+  },
+  xAxis: {
+    title: {
+      style,
       text: highchartData.xAxisTitle || '',
       ...X_AXIS_TITLE_POSITION
-    },
-    type: highchartData.yAxisType || 'linear'
+    }
   },
   tooltip: {
     crosshairs: highchartData.graphType == 'line' && {

--- a/src/main/resources/lib/highcharts/config.es6
+++ b/src/main/resources/lib/highcharts/config.es6
@@ -7,6 +7,20 @@ export const style = {
 }
 export const lineColor = '#21383a'
 
+// retain the offset, but move it outs of the labels-zone
+export const Y_AXIS_TITLE_POSITION = {
+  align: 'high',
+  offset: 0,
+  rotation: 0,
+  y: -15
+}
+
+// keep the title at the end, but leave it to HC to compute offset & y-position
+export const X_AXIS_TITLE_POSITION = {
+  align: 'high',
+  offset: undefined,
+  y: undefined
+}
 
 export const createConfig = (highchartData, displayName) => ({
   accessibility: {
@@ -163,15 +177,11 @@ export const createConfig = (highchartData, displayName) => ({
     title: {
       style,
       text: highchartData.yAxisTitle || '',
-      align: 'high',
-      offset: 0,
-      rotation: 0,
-      y: -15
+      ...Y_AXIS_TITLE_POSITION
     },
     xAxis: {
       text: highchartData.xAxisTitle || '',
-      align: 'high',
-      offset: 0
+      ...X_AXIS_TITLE_POSITION
     },
     type: highchartData.yAxisType || 'linear'
   },

--- a/src/main/resources/site/parts/highchart/highchart.es6
+++ b/src/main/resources/site/parts/highchart/highchart.es6
@@ -122,6 +122,7 @@ function renderPart(req, highchartIds) {
       }
 
       if (graphType === 'barNegative') {
+        // axes get flipped so interchange title positions
         config.series = graphData.series
         config.xAxis = {
           title: {
@@ -180,9 +181,8 @@ function renderPart(req, highchartIds) {
           // In other words, include 'bar' in this if-test, instead of putting it in the yAxis config
           tickmarkPlacement: (graphType == 'column' || graphType == 'bar') ? 'between' : 'on',
           title: {
-            style,
-            text: xAxisTitle,
-            align: 'high'
+            ...config.xAxis.title,
+            text: xAxisTitle
           },
           type: highchart.data.xAxisType || 'categories',
           tickWidth: 1,

--- a/src/main/resources/site/parts/highchart/highchart.es6
+++ b/src/main/resources/site/parts/highchart/highchart.es6
@@ -126,8 +126,7 @@ function renderPart(req, highchartIds) {
         config.series = graphData.series
         config.xAxis = {
           title: {
-            style,
-            text: xAxisTitle,
+            ...config.xAxis.title,
             ...Y_AXIS_TITLE_POSITION
           },
           categories: graphData.categories,

--- a/src/main/resources/site/parts/highchart/highchart.es6
+++ b/src/main/resources/site/parts/highchart/highchart.es6
@@ -1,4 +1,5 @@
 import JsonStat from 'jsonstat-toolkit'
+import { X_AXIS_TITLE_POSITION, Y_AXIS_TITLE_POSITION } from '../../../lib/highcharts/config'
 const util = __non_webpack_require__( '/lib/util')
 const {
   getMunicipality
@@ -126,10 +127,7 @@ function renderPart(req, highchartIds) {
           title: {
             style,
             text: xAxisTitle,
-            align: 'high',
-            rotation: 0,
-            offset: 0,
-            y: -15
+            ...Y_AXIS_TITLE_POSITION
           },
           categories: graphData.categories,
           reversed: false,
@@ -142,13 +140,9 @@ function renderPart(req, highchartIds) {
             description: xAxisLabel
           }
         }
-        config.yAxis = {
-          ...config.yAxis,
-          title: {
-            ...config.yAxis.title,
-            offset: undefined,
-            y: undefined
-          }
+        config.yAxis.title = {
+          ...config.yAxis.title,
+          ...X_AXIS_TITLE_POSITION
         }
       } else {
         let useGraphDataCategories = false
@@ -196,23 +190,15 @@ function renderPart(req, highchartIds) {
         }
 
         if (graphType === 'bar') {
-          config.yAxis = {
-            ...config.yAxis,
-            title: {
-              ...config.yAxis.title,
-              offset: undefined,
-              y: undefined
-            }
+          // the axes get flipped, so interchange the title positions
+          config.yAxis.title = {
+            ...config.yAxis.title,
+            ...X_AXIS_TITLE_POSITION
           }
 
-          config.xAxis = {
-            ...config.xAxis,
-            title: {
-              ...config.xAxis.title,
-              rotation: 0,
-              offset: 0,
-              y: -15
-            }
+          config.xAxis.title = {
+            ...config.xAxis.title,
+            ...Y_AXIS_TITLE_POSITION
           }
         }
       }

--- a/src/main/resources/site/parts/highchart/highchart.es6
+++ b/src/main/resources/site/parts/highchart/highchart.es6
@@ -126,7 +126,10 @@ function renderPart(req, highchartIds) {
           title: {
             style,
             text: xAxisTitle,
-            align: 'high'
+            align: 'high',
+            rotation: 0,
+            offset: 0,
+            y: -15
           },
           categories: graphData.categories,
           reversed: false,
@@ -137,6 +140,14 @@ function renderPart(req, highchartIds) {
           lineColor,
           accessibility: {
             description: xAxisLabel
+          }
+        }
+        config.yAxis = {
+          ...config.yAxis,
+          title: {
+            ...config.yAxis.title,
+            offset: undefined,
+            y: undefined
           }
         }
       } else {
@@ -158,6 +169,7 @@ function renderPart(req, highchartIds) {
           showLabels = true
         }
         config.series = graphData.series
+
         config.xAxis = {
           categories: useGraphDataCategories ? graphData.categories : [highchart.displayName],
           allowDecimals: !!highchart.data.xAllowDecimal,
@@ -181,6 +193,27 @@ function renderPart(req, highchartIds) {
           type: highchart.data.xAxisType || 'categories',
           tickWidth: 1,
           tickColor: '#21383a'
+        }
+
+        if (graphType === 'bar') {
+          config.yAxis = {
+            ...config.yAxis,
+            title: {
+              ...config.yAxis.title,
+              offset: undefined,
+              y: undefined
+            }
+          }
+
+          config.xAxis = {
+            ...config.xAxis,
+            title: {
+              ...config.xAxis.title,
+              rotation: 0,
+              offset: 0,
+              y: -15
+            }
+          }
         }
       }
 
@@ -211,9 +244,9 @@ function renderPart(req, highchartIds) {
         ...createConfig(highchart.data, highchart.displayName),
         data: {
           table: 'highcharts-datatable-' + highchart._id,
-          decimalPoint: ',',
-        },
-      };
+          decimalPoint: ','
+        }
+      }
     }
 
     return initHighchart(highchart, config)

--- a/src/main/resources/site/parts/highchart/highchart.es6
+++ b/src/main/resources/site/parts/highchart/highchart.es6
@@ -125,7 +125,8 @@ function renderPart(req, highchartIds) {
         config.xAxis = {
           title: {
             style,
-            text: xAxisTitle
+            text: xAxisTitle,
+            align: 'high'
           },
           categories: graphData.categories,
           reversed: false,
@@ -174,7 +175,8 @@ function renderPart(req, highchartIds) {
           tickmarkPlacement: (graphType == 'column' || graphType == 'bar') ? 'between' : 'on',
           title: {
             style,
-            text: xAxisTitle
+            text: xAxisTitle,
+            align: 'high'
           },
           type: highchart.data.xAxisType || 'categories',
           tickWidth: 1,


### PR DESCRIPTION
- Move y-axis title outside of the labels-zone but at the same offset
- No clean solution for the x-axis, though -- for now positioning the title at the right end, but leaving it to highcharts to render it below the labels.
- Works similar on all types of charts with axes

---
<img width="1030" alt="hc-axis" src="https://user-images.githubusercontent.com/62878049/83172069-532d0300-a117-11ea-8481-3bfef0b4cce4.png">
