### PR TITLE
Accordions and Glossary should always keep content in DOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -969,9 +969,9 @@
       }
     },
     "@statisticsnorway/ssb-component-library": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@statisticsnorway/ssb-component-library/-/ssb-component-library-2.0.21.tgz",
-      "integrity": "sha512-VjcWav3dOeFdcy9FkWODirA2Rwp1BBtZDNOlpd3fKYq6N4dzBC3VbXVvjKwz7cceEmQL287LblF1unOcxjmwBg==",
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@statisticsnorway/ssb-component-library/-/ssb-component-library-2.0.22.tgz",
+      "integrity": "sha512-66JtrHlbUw3TghEEZFXnameEPdExIl3Zd222TEneegiSKlbYpdIkCceQuf8s7SkKnfPWdiyp6sFkd5lxAiMG4w==",
       "requires": {
         "node-sass": "^4.13.0",
         "prismjs": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "@statisticsnorway/ssb-component-library": "^2.0.21",
+    "@statisticsnorway/ssb-component-library": "^2.0.22",
     "@types/react": "^16.9.17",
     "autoprefixer": "^9.7.3",
     "awesome-typescript-loader": "^5.2.1",


### PR DESCRIPTION
Fixed in https://github.com/statisticsnorway/ssb-component-library/pull/203