### PR TITLE
MIMIR-618 : show stacked totals

### DIFF
--- a/src/main/resources/lib/highcharts/config.es6
+++ b/src/main/resources/lib/highcharts/config.es6
@@ -22,6 +22,11 @@ export const X_AXIS_TITLE_POSITION = {
   y: undefined
 }
 
+const shouldShowStackingTotal = (highchartData) =>
+  (highchartData.graphType !== 'pie') &&
+  (highchartData.stacking === 'normal') &&
+  highchartData.showStackedTotal
+
 export const createConfig = (highchartData, displayName) => ({
   accessibility: {
     enabled: true,
@@ -168,7 +173,10 @@ export const createConfig = (highchartData, displayName) => ({
     max: highchartData.yAxisMax ? highchartData.yAxisMax.replace(/,/g, '.') : null,
     min: highchartData.yAxisMin ? highchartData.yAxisMin.replace(/,/g, '.') : null,
     stackLabels: {
-      enabled: highchartData.stablesum
+      enabled: shouldShowStackingTotal(highchartData),
+      // HC sets x or y := 0 by default, leaving no breathing space between the bar and the label
+      x: ((highchartData.graphType === 'bar') || (highchartData.graphType === 'barNegative')) ? 5 : 0,
+      y: ((highchartData.graphType === 'line') || (highchartData.graphType === 'area')) ? -5 : 0
     },
     tickWidth: 1,
     tickColor: '#21383a',

--- a/src/main/resources/site/content-types/highchart/highchart.ts
+++ b/src/main/resources/site/content-types/highchart/highchart.ts
@@ -30,6 +30,11 @@ export interface Highchart {
   stacking?: "disabled" | "normal" | "percent";
 
   /**
+   * Vis stabelsum
+   */
+  showStackedTotal: boolean;
+
+  /**
    * Skjul tegnforklaringen
    */
   noLegend: boolean;

--- a/src/main/resources/site/content-types/highchart/highchart.xml
+++ b/src/main/resources/site/content-types/highchart/highchart.xml
@@ -51,6 +51,14 @@
       <help-text>Grupperte verdier kan vises hver for seg (ingen stabling) eller summeres i en felles søyle med stabling</help-text>
     </input>
 
+    <input name="showStackedTotal" type="Checkbox">
+      <label>Vis stabelsum</label>
+      <help-text>
+        Hvis stabling av verdier er skrudd på OG dette feltet er avkrysset,
+        vises summen av alle verdiene fra en stabel som en etikett utenfor stabelen.
+        Er avslått som standard, da etikettene kan få plassproblemer ved større datasett og/eller store verdier.
+      </help-text>
+    </input>
 
     <input name="noLegend" type="CheckBox">
       <label>Skjul tegnforklaringen</label>

--- a/src/main/resources/site/content-types/highchart/highchart.xml
+++ b/src/main/resources/site/content-types/highchart/highchart.xml
@@ -52,7 +52,7 @@
     </input>
 
     <input name="showStackedTotal" type="Checkbox">
-      <label>Vis stabelsum</label>
+      <label>Vis samlet sum for stolpe</label>
       <help-text>
         Hvis stabling av verdier er skrudd på OG dette feltet er avkrysset,
         vises summen av alle verdiene fra en stabel som en etikett utenfor stabelen.


### PR DESCRIPTION
- Add option to show stacked totals (_highchart_ content-type)
- If stacking mode is 'normal' (cumulative) and show stacked totals is enabled, then display the total on top of (or by the side) of the stacking
- Works for _line_, _bar_, _column_, _area_ and _pyramid_ chart types
---
<img width="1726" alt="stack-1" src="https://user-images.githubusercontent.com/62878049/83564356-dd60d700-a51c-11ea-9d51-759842cd9823.png">
<img width="1362" alt="stack-2" src="https://user-images.githubusercontent.com/62878049/83564361-ddf96d80-a51c-11ea-83d6-c4b61c989e5e.png">
