### PR TITLE
MIMIR-615 : Highcharts Aspect Ratio

### DIFF
--- a/src/main/resources/lib/highcharts/config.es6
+++ b/src/main/resources/lib/highcharts/config.es6
@@ -30,6 +30,7 @@ export const createConfig = (highchartData, displayName) => ({
     }
   },
   chart: {
+    height: (highchartData.heightAspectRatio > 0) ? `${highchartData.heightAspectRatio}%` : null,
     plotBorderColor: '#e6e6e6',
     spacingBottom: 18,
     plotBorderWidth: 0,

--- a/src/main/resources/site/content-types/highchart/highchart.ts
+++ b/src/main/resources/site/content-types/highchart/highchart.ts
@@ -20,6 +20,11 @@ export interface Highchart {
   graphType: "line" | "pie" | "column" | "bar" | "area" | "barNegative";
 
   /**
+   * Høyde i prosent av bredde
+   */
+  heightAspectRatio?: string;
+
+  /**
    * Antall desimalplasser som vises
    */
   numberDecimals?: "0" | "1" | "2" | "3";

--- a/src/main/resources/site/content-types/highchart/highchart.xml
+++ b/src/main/resources/site/content-types/highchart/highchart.xml
@@ -29,6 +29,15 @@
       <default>line</default>
     </input>
 
+    <input name="heightAspectRatio" type="TextLine">
+      <label>Høyde i prosent av bredde</label>
+      <default>75</default>
+      <help-text>
+        Et heltall større enn 0. Anbefalt er 75 som gir 4:3-forhold. 100 er kvadrat (1:1),
+        62 er det gylne snitt liggende, 56 er kinolerret (16:9), 162 er det gylne snitt stående.
+      </help-text>
+    </input>
+
     <input name="numberDecimals" type="RadioButton">
       <label>Antall desimalplasser som vises</label>
       <config>


### PR DESCRIPTION
Allow specifying aspect ratio of the chart (expressed as percentage of height wrt. width of the chart)

| % specified | Aspect Ratio |
|-------------|--------------|
| 100 | 1:1 |
|75 | 4:3 (_default_) |
| 62 | Golden Ratio |
| 56 | 16:9 |
| 162 | Golden Ratio (vertical) |
| 0 | Highcharts default |

---
<img width="1301" alt="hc_aspect_ratio" src="https://user-images.githubusercontent.com/62878049/84010104-7b68fd00-a974-11ea-9a6d-cd4533335ba4.png">