### PR TITLE
MIMIR-640: Make menuitem active

### DIFF
--- a/src/main/resources/site/pages/default/default.es6
+++ b/src/main/resources/site/pages/default/default.es6
@@ -145,7 +145,7 @@ exports.get = function(req) {
     pageContributions = preview.pageContributions
   }
 
-  const header = fromMenuCache(req, 'header', () => {
+  const header = fromMenuCache(req, `header_${req.path}`, () => {
     const headerContent = getHeaderContent(language)
     if (headerContent) {
       const headerComponent = new React4xp('Header')


### PR DESCRIPTION
If a current content has parts of a menuitems "manual" url, make the menuitem active
- Add a check of current content path
- Extend cache name with url path, so that each path has its own cached menu

MIMIR-640