### PR TITLE
Mimir 679 indents titles content

### DIFF
--- a/src/main/resources/assets/styles/_contacts.scss
+++ b/src/main/resources/assets/styles/_contacts.scss
@@ -1,14 +1,14 @@
 .part-contacts {
   .contacts {
-    .part-contact--name {
+    .part-contact-name {
       font-weight: bold;
       color: $ssb-dark-6;
       font-size: 20px;
       line-height: 32px;
     }
 
-    .part-contact--email,
-    .part-contact--telephone {
+    .part-contact-email,
+    .part-contact-telephone {
       font-size: 16px;
       line-height: 28px;
     }

--- a/src/main/resources/assets/styles/_contacts.scss
+++ b/src/main/resources/assets/styles/_contacts.scss
@@ -1,5 +1,5 @@
 .part-contacts {
-  .part-contact {
+  .contacts {
     .part-contact--name {
       font-weight: bold;
       color: $ssb-dark-6;
@@ -11,6 +11,11 @@
     .part-contact--telephone {
       font-size: 16px;
       line-height: 28px;
+    }
+
+    @include media-breakpoint-down(md) {
+      padding: 0;
+      margin-top: $spacer * 2;
     }
   }
 }

--- a/src/main/resources/site/layouts/columns/columns.html
+++ b/src/main/resources/site/layouts/columns/columns.html
@@ -1,6 +1,10 @@
 <div class="col xp-layout">
-  <h3 data-th-if="${hideTitle && title}" class="sr-only sr-only-focusable" data-th-text="${title}"></h3>
-  <h3 data-th-if="${!hideTitle && title}" class="layout-title" data-th-text="${title}"></h3>
+  <div class="container">
+    <div class="row">
+      <h3 data-th-if="${hideTitle && title}" class="sr-only sr-only-focusable col" data-th-text="${title}"></h3>
+      <h3 data-th-if="${!hideTitle && title}" class="layout-title col" data-th-text="${title}"></h3>
+    </div>
+  </div>
   <div class="row row-cols-1 row-cols-md-2">
     <div data-th-if="${!isGrid}" data-th-remove="tag">
       <div data-portal-region="left" class="xp-region" data-th-classappend="${leftSize}">

--- a/src/main/resources/site/layouts/columns/columns.html
+++ b/src/main/resources/site/layouts/columns/columns.html
@@ -1,8 +1,10 @@
 <div class="col xp-layout">
   <div class="container">
     <div class="row">
-      <h3 data-th-if="${hideTitle && title}" class="sr-only sr-only-focusable col" data-th-text="${title}"></h3>
-      <h3 data-th-if="${!hideTitle && title}" class="layout-title col" data-th-text="${title}"></h3>
+      <div class="col">
+        <h3 data-th-if="${hideTitle && title}" class="sr-only sr-only-focusable" data-th-text="${title}"></h3>
+        <h3 data-th-if="${!hideTitle && title}" class="layout-title" data-th-text="${title}"></h3>
+      </div>
     </div>
   </div>
   <div class="row row-cols-1 row-cols-md-2">

--- a/src/main/resources/site/layouts/topic/topic.html
+++ b/src/main/resources/site/layouts/topic/topic.html
@@ -1,6 +1,10 @@
 <div class="col xp-layout">
-  <h3 data-th-if="${hideTitle && title}" class="sr-only sr-only-focusable" data-th-text="${title}"></h3>
-  <h3 data-th-if="${!hideTitle && title}" class="layout-title" data-th-text="${title}"></h3>
+  <div class="container">
+    <div class="row">
+      <h3 data-th-if="${hideTitle && title}" class="sr-only sr-only-focusable col" data-th-text="${title}"></h3>
+      <h3 data-th-if="${!hideTitle && title}" class="layout-title col" data-th-text="${title}"></h3>
+    </div>
+  </div>
   <div class="row row-cols-1">
     <div class="col xp-region" data-portal-region="main">
       <div data-th-each="component, i : ${mainRegion.components}" data-th-remove="tag">

--- a/src/main/resources/site/layouts/topic/topic.html
+++ b/src/main/resources/site/layouts/topic/topic.html
@@ -1,8 +1,10 @@
 <div class="col xp-layout">
   <div class="container">
     <div class="row">
-      <h3 data-th-if="${hideTitle && title}" class="sr-only sr-only-focusable col" data-th-text="${title}"></h3>
-      <h3 data-th-if="${!hideTitle && title}" class="layout-title col" data-th-text="${title}"></h3>
+      <div class="col">
+        <h3 data-th-if="${hideTitle && title}" class="sr-only sr-only-focusable" data-th-text="${title}"></h3>
+        <h3 data-th-if="${!hideTitle && title}" class="layout-title" data-th-text="${title}"></h3>
+      </div>
     </div>
   </div>
   <div class="row row-cols-1">

--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -68,7 +68,8 @@
       <div
         data-th-classappend="${region.view == 'full' ? 'container-fluid p-0' : region.view == 'card' ? 'border-top-green container' : 'container'}"
       >
-        <div class="col xp-layout">
+        <!-- Title for content in default pages -->
+        <div data-th-if="${region.view != 'card'}" class="col xp-layout">
           <div class="row row-cols-1">
             <div class="container">
               <div class="row">
@@ -78,6 +79,10 @@
             </div>
           </div>
         </div>
+
+        <!-- Title for content in border-top-green containers -->
+        <h2 data-th-if="${region.view == 'card' && region.hideTitle && region.title}" class="sr-only sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
+        <h2 data-th-if="${region.view == 'card' && !region.hideTitle && region.title}" class="mb-5" data-th-text="${region.title}"></h2>
 
         <div
           class="row row-cols-1"

--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -36,8 +36,7 @@
   <!-- MAIN -->
   <main class="xp-region"  id="content" data-th-if="${!isFragment}">
     <div class="container">
-      <div class="col xp-layout">
-        <div class="row row-cols-1">
+      <div class="row col">
           <div class="container bg-white pt-2 pb-4">
             <!-- breadcrumbs -->
             <div id="breadcrumbs" class="d-print-none"></div>
@@ -53,7 +52,6 @@
             </div>
           </div>
         </div>
-      </div>
     </div>
 
     <!-- preview -->
@@ -68,19 +66,17 @@
       <div
         data-th-classappend="${region.view == 'full' ? 'container-fluid p-0' : region.view == 'card' ? 'border-top-green container' : 'container'}"
       >
-        <!-- Title for content in default pages -->
-        <div data-th-if="${region.view != 'card'}" class="col xp-layout">
-          <div class="row row-cols-1">
-            <div class="container">
-              <div class="row">
-                <h2 data-th-if="${region.hideTitle && region.title}" class="sr-only col sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
-                <h2 data-th-if="${!region.hideTitle && region.title}" class="col mb-5" data-th-text="${region.title}"></h2>
-              </div>
+        <!-- Subtitle for content in default pages -->
+        <div data-th-if="${region.view != 'card'}" class="col row">
+          <div class="container">
+            <div class="row">
+              <h2 data-th-if="${region.hideTitle && region.title}" class="sr-only col sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
+              <h2 data-th-if="${!region.hideTitle && region.title}" class="col mb-5" data-th-text="${region.title}"></h2>
             </div>
           </div>
         </div>
 
-        <!-- Title for content in border-top-green containers -->
+        <!-- Subtitle for content in border-top-green containers -->
         <h2 data-th-if="${region.view == 'card' && region.hideTitle && region.title}" class="sr-only sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
         <h2 data-th-if="${region.view == 'card' && !region.hideTitle && region.title}" class="mb-5" data-th-text="${region.title}"></h2>
 

--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -68,8 +68,17 @@
       <div
         data-th-classappend="${region.view == 'full' ? 'container-fluid p-0' : region.view == 'card' ? 'border-top-green container' : 'container'}"
       >
-        <h2 data-th-if="${region.hideTitle && region.title}" class="sr-only sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
-        <h2 data-th-if="${!region.hideTitle && region.title}" class="mb-5" data-th-text="${region.title}"></h2>
+        <div class="col xp-layout">
+          <div class="row row-cols-1">
+            <div class="container">
+              <div class="row">
+                <h2 data-th-if="${region.hideTitle && region.title}" class="sr-only col sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
+                <h2 data-th-if="${!region.hideTitle && region.title}" class="col mb-5" data-th-text="${region.title}"></h2>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div
           class="row row-cols-1"
           data-th-data-portal-region="${region.region}"

--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -35,31 +35,29 @@
 
   <!-- MAIN -->
   <main class="xp-region"  id="content" data-th-if="${!isFragment}">
-    <div class="container-fluid bg-white pt-2 pb-4">
-      <!-- breadcrumbs -->
-      <div id="breadcrumbs" class="container d-print-none"></div>
+    <div class="container">
+      <div class="col xp-layout">
+        <div class="row row-cols-1">
+          <div class="container bg-white pt-2 pb-4">
+            <!-- breadcrumbs -->
+            <div id="breadcrumbs" class="d-print-none"></div>
 
-      <!-- Alerts Info and error -->
-      <section class="xp-part container pt-2" id="alerts"></section>
-    </div>
+            <!-- Alerts Info and error -->
+            <section class="xp-part pt-2" id="alerts"></section>
+          </div>
 
-    <!-- Page Title -->
-    <div data-th-if="${page.data.title}" class="container-fluid">
-      <div class="container mb-5">
-        <div class="row">
-          <h1 class="col" data-th-text="${page.data.title}"></h1>
+          <!-- Page Title -->
+          <div data-th-if="${page.data.title}" class="container mb-5">
+            <div class="row">
+              <h1 class="col" data-th-text="${page.data.title}"></h1>
+            </div>
+          </div>
         </div>
       </div>
     </div>
 
     <!-- preview -->
     <div class="container pt-5" data-th-if="${preview}" data-th-utext="${preview.body}">
-    </div>
-
-    <div data-th-if="${showIngress}" class="container ingress">
-      <div class="row">
-        <div class="mt-3 mt-md-0 col-lg-8" data-th-utext="${ingress}"></div>
-      </div>
     </div>
 
     <div

--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -43,8 +43,13 @@
       <section class="xp-part container pt-2" id="alerts"></section>
     </div>
 
-    <div data-th-if="${page.data.title}" class="container mb-5">
-      <h1 data-th-text="${page.data.title}"></h1>
+    <!-- Page Title -->
+    <div data-th-if="${page.data.title}" class="container-fluid">
+      <div class="container mb-5">
+        <div class="row">
+          <h1 class="col" data-th-text="${page.data.title}"></h1>
+        </div>
+      </div>
     </div>
 
     <!-- preview -->

--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -36,7 +36,8 @@
   <!-- MAIN -->
   <main class="xp-region"  id="content" data-th-if="${!isFragment}">
     <div class="container">
-      <div class="row col">
+      <div class="row">
+        <div class="col">
           <div class="container bg-white pt-2 pb-4">
             <!-- breadcrumbs -->
             <div id="breadcrumbs" class="d-print-none"></div>
@@ -48,10 +49,13 @@
           <!-- Page Title -->
           <div data-th-if="${page.data.title}" class="container mb-5">
             <div class="row">
-              <h1 class="col" data-th-text="${page.data.title}"></h1>
+              <div class="col">
+                <h1 data-th-text="${page.data.title}"></h1>
+              </div>
             </div>
           </div>
         </div>
+      </div>
     </div>
 
     <!-- preview -->
@@ -67,11 +71,15 @@
         data-th-classappend="${region.view == 'full' ? 'container-fluid p-0' : region.view == 'card' ? 'border-top-green container' : 'container'}"
       >
         <!-- Subtitle for content in default pages -->
-        <div data-th-if="${region.view != 'card'}" class="col row">
-          <div class="container">
-            <div class="row">
-              <h2 data-th-if="${region.hideTitle && region.title}" class="sr-only col sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
-              <h2 data-th-if="${!region.hideTitle && region.title}" class="col mb-5" data-th-text="${region.title}"></h2>
+        <div data-th-if="${region.view != 'card'}" class="row">
+          <div class="col">
+            <div class="container">
+              <div class="row">
+                <div class="col">
+                  <h2 data-th-if="${region.hideTitle && region.title}" class="sr-only sr-only-focusable mb-5" data-th-text="${region.title}"></h2>
+                  <h2 data-th-if="${!region.hideTitle && region.title}" class="mb-5" data-th-text="${region.title}"></h2>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/main/resources/site/parts/contact/contact.html
+++ b/src/main/resources/site/parts/contact/contact.html
@@ -2,15 +2,15 @@
   <h2 data-th-text="${label}?: 'Kontakt'" class="roboto-condensed-bold mb-md-4 pb-md-3 bt-6"></h2>
   <div data-th-each="contactGroup : ${contacts}" class="row d-flex flex-wrap">
     <div data-th-if="${contact}" data-th-each="contact : ${contactGroup}" class="col-8 col-md-3 contacts">
-      <p class="roboto-plain lead mb-1 text-break text-wrap part-contact--name" data-th-text=${contact.name}>
+      <p class="roboto-plain lead mb-1 text-break text-wrap part-contact-name" data-th-text=${contact.name}>
         TESTNAVN
       </p>
-      <p data-th-if="${contact.email}" class="part-contact--email mb-1">
+      <p data-th-if="${contact.email}" class="part-contact-email mb-1">
         <a class="roboto-plain" data-th-href="@{'mailto:' + ${contact.email}}" data-th-text="${contact.email}">
           epost
         </a>
       </p>
-      <p data-th-if="${contact.telephone}" data-th-text="${contact.telephone}" class="part-contact--telephone">
+      <p data-th-if="${contact.telephone}" data-th-text="${contact.telephone}" class="part-contact-telephone">
         phone
       </p>
     </div>

--- a/src/main/resources/site/parts/contact/contact.html
+++ b/src/main/resources/site/parts/contact/contact.html
@@ -1,20 +1,18 @@
 <section class="xp-part part-contacts container mt-md-5 pt-3" data-th-if="${contacts}">
-  <h2 data-th-text="${label}?: 'Kontakt'" class="roboto-condensed-bold mb-md-4 pb-md-2 bt-6"></h2>
-  <div data-th-each="contactGroup : ${contacts}" class="row d-flex flex-wrap part-contact">
-    <div data-th-each="contact : ${contactGroup}" class="col-8 col-md-3 contact">
-      <div data-th-if="${contact}">
-        <p class="roboto-plain lead mb-1 text-break text-wrap part-contact--name" data-th-text=${contact.name}>
-          TESTNAVN
-        </p>
-        <p data-th-if="${contact.email}" class="part-contact-email">
-          <a class="roboto-plain" data-th-href="@{'mailto:' + ${contact.email}}" data-th-text="${contact.email}">
-            epost
-          </a>
-        </p>
-        <p data-th-if="${contact.telephone}" data-th-text="${contact.telephone}" class="part-contact--telephone">
-          phone
-        </p>
-      </div>
+  <h2 data-th-text="${label}?: 'Kontakt'" class="roboto-condensed-bold mb-md-4 pb-md-3 bt-6"></h2>
+  <div data-th-each="contactGroup : ${contacts}" class="row d-flex flex-wrap">
+    <div data-th-if="${contact}" data-th-each="contact : ${contactGroup}" class="col-8 col-md-3 contacts">
+      <p class="roboto-plain lead mb-1 text-break text-wrap part-contact--name" data-th-text=${contact.name}>
+        TESTNAVN
+      </p>
+      <p data-th-if="${contact.email}" class="part-contact--email mb-1">
+        <a class="roboto-plain" data-th-href="@{'mailto:' + ${contact.email}}" data-th-text="${contact.email}">
+          epost
+        </a>
+      </p>
+      <p data-th-if="${contact.telephone}" data-th-text="${contact.telephone}" class="part-contact--telephone">
+        phone
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
- Nests titles for one and two column layouts in container, row, and column.
- Breadcrumbs, alerts, and titles are also nested in a container, row and column along with a few minor tweaks to each element.
- Tweaks h2 title for containers with a green border on top and adds another for plain pages.
- CSS adjustments for the contacts, mobile version.

These changes should fix the indent for titles (including Data til Forskning) and content in articles (contacts) in any resolution.