### PR TITLE
MIMIR-491 : Contrast bg for picture cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "@statisticsnorway/ssb-component-library": "^2.0.28",
+    "@statisticsnorway/ssb-component-library": "^2.0.29",
     "@types/react": "^16.9.17",
     "autoprefixer": "^9.7.3",
     "awesome-typescript-loader": "^5.2.1",

--- a/src/main/resources/site/parts/relatedFactPage/relatedFactPage.jsx
+++ b/src/main/resources/site/parts/relatedFactPage/relatedFactPage.jsx
@@ -28,7 +28,7 @@ class RelatedBoxes extends React.Component {
           {relatedContentLists.map((relatedRelatedContent, index) =>
             <PictureCard
               className={`mb-3 ${index > 3 && this.state.isHidden ? 'd-none' : ''}`}
-              image={<img src={relatedRelatedContent.image} alt={relatedRelatedContent.imageAlt}/>}
+              imageSrc={relatedRelatedContent.image} altText={relatedRelatedContent.imageAlt}
               link={relatedRelatedContent.link}
               type={relatedRelatedContent.type ? relatedRelatedContent.type : undefined}
               title={relatedRelatedContent.title}


### PR DESCRIPTION
Use new version of SSB Component Library ([v2.0.29](https://github.com/statisticsnorway/ssb-component-library/releases/tag/2.0.29)) with fix for contrast bg in picture cards