### PR TITLE
MIMIR-703 : Use new statreg endpoint for statistics

### DIFF
--- a/src/main/resources/lib/repo/statreg/statistics.ts
+++ b/src/main/resources/lib/repo/statreg/statistics.ts
@@ -1,7 +1,7 @@
 import { find } from 'ramda'
 import { getStatRegNode, StatRegNode } from '../statreg'
 import { fetchStatistics as fetchStatisticsSvc } from '../../ssb/statreg'
-import { Statistic } from '../../ssb/statreg/types'
+import { StatisticInListing as Statistic } from '../../ssb/statreg/types'
 import { ensureArray } from '../../ssb/arrayUtils'
 
 export const STATREG_REPO_STATISTICS_KEY: string = 'statistics'

--- a/src/main/resources/lib/ssb/statreg/common.ts
+++ b/src/main/resources/lib/ssb/statreg/common.ts
@@ -16,21 +16,22 @@ export function fetchStatRegData<T, XmlType>(
   dataKey: string,
   serviceUrl: string,
   filters: QueryFilters,
-  extractor: (xml: XmlType) => Array<T>): Array<T> {
+  extractor: (payload: string) => Array<T>): Array<T> {
+
   const result: HttpResponse = http.request({
-    url: `${serviceUrl}/${filtersToQuery(filters)}`,
+    url: `${serviceUrl}${filtersToQuery(filters)}`,
     method: 'GET',
     contentType: 'application/json',
     headers: {
       'Cache-Control': 'no-cache',
       'Accept': 'application/json'
     },
-    connectionTimeout: 20000,
-    readTimeout: 5000
+    connectionTimeout: 500000000,
+    readTimeout: 500000000
   })
 
   if ((result.status === 200) && result.body) {
-    const data: Array<T> = extractor(__.toNativeObject(xmlParser.parse(result.body)))
+    const data: Array<T> = extractor(result.body)
     log.info(`Fetched ${data ? data.length : 0} ${dataKey}`)
     return data
   }

--- a/src/main/resources/lib/ssb/statreg/common.ts
+++ b/src/main/resources/lib/ssb/statreg/common.ts
@@ -26,8 +26,8 @@ export function fetchStatRegData<T, XmlType>(
       'Cache-Control': 'no-cache',
       'Accept': 'application/json'
     },
-    connectionTimeout: 500000000,
-    readTimeout: 500000000
+    connectionTimeout: 30000,
+    readTimeout: 30000
   })
 
   if ((result.status === 200) && result.body) {

--- a/src/main/resources/lib/ssb/statreg/config.ts
+++ b/src/main/resources/lib/ssb/statreg/config.ts
@@ -3,5 +3,5 @@ export const STAT_REG: string = `${app.config && app.config[STAT_REG_SVC_PROP]}`
 
 export const CONTACTS_URL: string = `${STAT_REG}/kontakt/listSomXml`
 // export const STATISTICS_URL: string = `${STAT_REG}/statistikk/listSomXml`
-export const STATISTICS_URL: string = `${STAT_REG}/statistikk/listAllePubliserteSomXml`
+export const STATISTICS_URL: string = `${STAT_REG}/statistics`
 export const PUBLICATIONS_URL: string = `${STAT_REG}/publisering/listSomXml`

--- a/src/main/resources/lib/ssb/statreg/index.ts
+++ b/src/main/resources/lib/ssb/statreg/index.ts
@@ -3,6 +3,7 @@ import { STATISTICS_URL, CONTACTS_URL, PUBLICATIONS_URL } from './config'
 import { extractStatistics, extractContacts, extractPublications } from './types'
 import { fetchStatRegData } from './common'
 
+
 export function fetchStatistics(filters: QueryFilters) {
   return fetchStatRegData('Statistics', STATISTICS_URL, filters, extractStatistics)
 }

--- a/src/main/resources/lib/ssb/statreg/types.ts
+++ b/src/main/resources/lib/ssb/statreg/types.ts
@@ -1,4 +1,6 @@
 import { find } from 'ramda'
+import { XmlParser } from '../../types/xmlParser'
+const xmlParser: XmlParser = __.newBean('no.ssb.xp.xmlparser.XmlParser')
 
 // XML response types (Common)
 
@@ -61,56 +63,42 @@ export function transformContact(kontakt: Kontakt): Contact {
   } as Contact
 }
 
-export function extractContacts(kontaktXML: KontaktXML): Array<Contact> {
+export function extractContacts(payload: string): Array<Contact> {
+  const kontaktXML: KontaktXML = __.toNativeObject(xmlParser.parse(payload))
   const kontakter: Array<Kontakt> = kontaktXML.kontakter.kontakt
   return kontakter.map((k) => transformContact(k))
 }
 
 // XML response types for Statistics from StatReg ----------------------------------
 
-export interface Statistikk {
-    id: string;
-    kortnavn: string;
-    navn: string;
-    status: string;
-    deskFlyt: string;
-    dirFlyt: string;
-    endret: string;
+/**
+ * NOTE:
+ * The following '.*Listing' types are only the basic information that comes with the
+ * GET /statistics listing endpoint. This has to be extended
+ * (and named properly as Variant & Statistic) when we start using the
+ * GET /statistics/{shortName} endpoint
+ */
+export interface VariantInListing {
+    frekvens: string;
+    previousRelease: string;
+    nextRelease: string;
 }
 
-export interface StatistikkListe extends ListMeta {
-    statistikk: Array<Statistikk>;
-}
-
-export interface StatistikkXML {
-    statistikker: StatistikkListe;
-}
-
-export interface Statistic {
+export interface StatisticInListing {
     id: string;
     shortName: string;
     name: string;
     status: string;
     modifiedTime: string;
+    variants: Array<VariantInListing>;
 }
 
-export function transformStat(stat: Statistikk): Statistic {
-  const {
-    id, kortnavn: shortName, navn: name, status, endret: modifiedTime
-  } = stat
-
-  return {
-    id,
-    shortName,
-    name,
-    status,
-    modifiedTime
-  }
+export interface Statistics {
+    statistics: Array<StatisticInListing>;
 }
 
-export function extractStatistics(statXML: StatistikkXML): Array<Statistic> {
-  const statistikk: Array<Statistikk> = statXML.statistikker.statistikk
-  return statistikk.map((stat) => transformStat(stat))
+export function extractStatistics(payload: string): Array<StatisticInListing> {
+  return JSON.parse(payload).statistics
 }
 
 // XML response types from StatReg for Publications --------------------------------
@@ -153,7 +141,8 @@ export function transformPubllication(pub: Publisering): Publication {
   }
 }
 
-export function extractPublications(pubXML: PubliseringXML): Array<Publication> {
+export function extractPublications(payload: string): Array<Publication> {
+  const pubXML: PubliseringXML = __.toNativeObject(xmlParser.parse(payload))
   const publisering: Array<Publisering> = pubXML.publiseringer.publisering
   return publisering.map((pub) => transformPubllication(pub))
 }


### PR DESCRIPTION
- use new statreg endpoint **GET** `{statreg}/statistics` (ref: [documentation](https://wiki.ssb.no/display/NYP/StatReg%3A+Suggestions+for+new+endpoints))
- refractor code to support both xml and json response from statreg api
----
- **OBS**: setting a huge conn- and readTimeout (`500s`) as the endpoint regularly failed to fetch from utv/test. 
  - this value will be updated once it is confirmed to work with meaningful values for the timeouts (`30s`)