### PR TITLE
Mimir 666: Display data from statreg for Statistics pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2020,12 +2020,14 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -5246,12 +5248,14 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -7465,7 +7469,8 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -969,9 +969,9 @@
       }
     },
     "@statisticsnorway/ssb-component-library": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@statisticsnorway/ssb-component-library/-/ssb-component-library-2.0.28.tgz",
-      "integrity": "sha512-h4xR5RMFR0uVJq97EN3JuRbcxYX84aEjPtXeifYbWPA84ldiW0zwCmknTcE5nZGXMUC6T4Bd2jvVS3UdrSv1cQ==",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@statisticsnorway/ssb-component-library/-/ssb-component-library-2.0.29.tgz",
+      "integrity": "sha512-quWU9TfbMRN2aYedb7DzkNN4x+hHjcM2s/kEVMbwkAcJldey67AwJ632EeTK+nd2hnYXQqeFfdGY+wFZYBvk8g==",
       "requires": {
         "node-sass": "^4.14.1",
         "prismjs": "^1.17.1",

--- a/src/main/resources/assets/styles/_statistics.scss
+++ b/src/main/resources/assets/styles/_statistics.scss
@@ -7,7 +7,6 @@
       @include make-col(12);
 
       h1 {
-        margin-bottom: $spacer * 3;
         padding: 0;
       }
 

--- a/src/main/resources/assets/styles/_statistics.scss
+++ b/src/main/resources/assets/styles/_statistics.scss
@@ -1,29 +1,19 @@
-.statistic {
-  display: flex;
+.statistics {
+  .titles-dates-wrapper {
+    @include make-row;
 
-  span {
-    margin-right: 1rem;
-  }
+    > * {
+      @include make-col-ready();
+      @include make-col(12);
 
-  .shortName {
-    font-weight: bold;
-  }
-}
+      h1 {
+        margin-bottom: $spacer * 3;
+        padding: 0;
+      }
 
-.publicationsTable {
-  display: flex;
-  flex-direction: column;
-  margin: 1rem 0;
-}
-
-.publication {
-  display: flex;
-
-  span {
-    padding: 0.25rem;
-  }
-
-  &.header span {
-    font-weight: bold;
+      @include media-breakpoint-down(md) {
+        padding: 0;
+      }
+    }
   }
 }

--- a/src/main/resources/site/content-types/articleArchive/articleArchive.ts
+++ b/src/main/resources/site/content-types/articleArchive/articleArchive.ts
@@ -1,6 +1,6 @@
 export interface ArticleArchive {
   /**
-   * Tittel
+   * Tittel på artikkelarkivet/samlesiden
    */
   title?: string;
 
@@ -12,7 +12,7 @@ export interface ArticleArchive {
   /**
    * Bilde
    */
-  bilde?: string;
+  image?: string;
 
   /**
    * ISSN-nummer

--- a/src/main/resources/site/i18n/phrases.properties
+++ b/src/main/resources/site/i18n/phrases.properties
@@ -160,5 +160,7 @@ notRelevant = Ikke relevant
 
 statbankBox.title = Finn flere tall i Statistikkbanken
 
+updated = Oppdatert
+nextUpdate = Neste oppdatering
 notAvailable = Ikke tilgjengelig
 notYetDetermined = Foreløpig ikke fastsatt

--- a/src/main/resources/site/i18n/phrases.properties
+++ b/src/main/resources/site/i18n/phrases.properties
@@ -159,3 +159,6 @@ postingProcedures = Publiseringsrutiner
 notRelevant = Ikke relevant
 
 statbankBox.title = Finn flere tall i Statistikkbanken
+
+notAvailable = Ikke tilgjengelig
+notYetDetermined = Foreløpig ikke fastsatt

--- a/src/main/resources/site/i18n/phrases_en.properties
+++ b/src/main/resources/site/i18n/phrases_en.properties
@@ -159,3 +159,6 @@ postingProcedures = Posting procedures
 notRelevant = Not relevant
 
 statbankBox.title = Find more figures in Statbank
+
+notAvailable = Not available
+notYetDetermined = Not yet determined

--- a/src/main/resources/site/i18n/phrases_en.properties
+++ b/src/main/resources/site/i18n/phrases_en.properties
@@ -160,5 +160,7 @@ notRelevant = Not relevant
 
 statbankBox.title = Find more figures in Statbank
 
+updated = Updated
+nextUpdate = Next update
 notAvailable = Not available
 notYetDetermined = Not yet determined

--- a/src/main/resources/site/i18n/phrases_no.properties
+++ b/src/main/resources/site/i18n/phrases_no.properties
@@ -158,5 +158,7 @@ notRelevant = Ikke relevant
 
 statbankBox.title = Finn flere tall i Statistikkbanken
 
+updated = Oppdatert
+nextUpdate = Neste oppdatering
 notAvailable = Ikke tilgjengelig
 notYetDetermined = Foreløpig ikke fastsatt

--- a/src/main/resources/site/i18n/phrases_no.properties
+++ b/src/main/resources/site/i18n/phrases_no.properties
@@ -157,3 +157,6 @@ postingProcedures = Publiseringsrutiner
 notRelevant = Ikke relevant
 
 statbankBox.title = Finn flere tall i Statistikkbanken
+
+notAvailable = Ikke tilgjengelig
+notYetDetermined = Foreløpig ikke fastsatt

--- a/src/main/resources/site/parts/statistics/statistics.es6
+++ b/src/main/resources/site/parts/statistics/statistics.es6
@@ -47,7 +47,7 @@ const renderPart = (req) => {
     }
 
     if (statistic.variants.nextRelease && statistic.variants.nextRelease !== '') {
-      nextRelease =moment(statistic.variants.nextRelease).format('DD. MMMM YYYY')
+      nextRelease = moment(statistic.variants.nextRelease).format('DD. MMMM YYYY')
     }
   }
 

--- a/src/main/resources/site/parts/statistics/statistics.es6
+++ b/src/main/resources/site/parts/statistics/statistics.es6
@@ -37,7 +37,7 @@ const renderPart = (req) => {
   const updated = phrases.updated + ': '
   const nextUpdate = phrases.nextUpdate + ': '
   let previousRelease = phrases.notAvailable
-  const nextRelease = phrases.notYetDetermined
+  let nextRelease = phrases.notYetDetermined
 
   if (statistic) {
     title = statistic.name
@@ -47,7 +47,7 @@ const renderPart = (req) => {
     }
 
     if (statistic.variants.nextRelease && statistic.variants.nextRelease !== '') {
-      moment(statistic.variants.nextRelease).format('DD. MMMM YYYY')
+      nextRelease =moment(statistic.variants.nextRelease).format('DD. MMMM YYYY')
     }
   }
 

--- a/src/main/resources/site/parts/statistics/statistics.es6
+++ b/src/main/resources/site/parts/statistics/statistics.es6
@@ -34,6 +34,8 @@ const renderPart = (req) => {
   const statistic = page.data.statistic && getStatisticByIdFromRepo(page.data.statistic)
 
   let title = page.displayName
+  const updated = phrases.updated + ': '
+  const nextUpdate = phrases.nextUpdate + ': '
   let previousRelease = phrases.notAvailable
   const nextRelease = phrases.notYetDetermined
 
@@ -51,6 +53,8 @@ const renderPart = (req) => {
 
   const model = {
     title,
+    updated,
+    nextUpdate,
     previousRelease,
     nextRelease
   }

--- a/src/main/resources/site/parts/statistics/statistics.es6
+++ b/src/main/resources/site/parts/statistics/statistics.es6
@@ -1,9 +1,9 @@
-import { getPublicationsForStatistic } from '../../../lib/repo/statreg/publications'
-import { getStatisticByIdFromRepo } from '../../../lib/repo/statreg/statistics'
-
 const {
   getContent
 } = __non_webpack_require__('/lib/xp/portal')
+const {
+  getStatisticByIdFromRepo
+} = __non_webpack_require__('/lib/repo/statreg/statistics')
 const {
   render
 } = __non_webpack_require__('/lib/thymeleaf')
@@ -26,12 +26,10 @@ exports.preview = (req) => renderPart(req)
 const renderPart = (req) => {
   const page = getContent()
   const statistic = page.data.statistic && getStatisticByIdFromRepo(page.data.statistic)
-  const publications = statistic && getPublicationsForStatistic(statistic.shortName)
 
   const model = {
     title: page.displayName,
-    statistic,
-    publications
+    statistic
   }
 
   const body = render(view, model)

--- a/src/main/resources/site/parts/statistics/statistics.es6
+++ b/src/main/resources/site/parts/statistics/statistics.es6
@@ -5,12 +5,16 @@ const {
   getStatisticByIdFromRepo
 } = __non_webpack_require__('/lib/repo/statreg/statistics')
 const {
+  getPhrases
+} = __non_webpack_require__( '/lib/language')
+const {
   render
 } = __non_webpack_require__('/lib/thymeleaf')
 const {
   renderError
 } = __non_webpack_require__('/lib/error/error')
 
+const moment = require('moment/min/moment-with-locales')
 const view = resolve('./statistics.html')
 
 exports.get = (req) => {
@@ -25,11 +29,30 @@ exports.preview = (req) => renderPart(req)
 
 const renderPart = (req) => {
   const page = getContent()
+  const phrases = getPhrases(page)
+  moment.locale(page.language ? page.language : 'nb')
   const statistic = page.data.statistic && getStatisticByIdFromRepo(page.data.statistic)
 
+  let title = page.displayName
+  let previousRelease = phrases.notAvailable
+  const nextRelease = phrases.notYetDetermined
+
+  if (statistic) {
+    title = statistic.name
+
+    if (statistic.variants.previousRelease && statistic.variants.previousRelease !== '') {
+      previousRelease = moment(statistic.variants.previousRelease).format('DD. MMMM YYYY')
+    }
+
+    if (statistic.variants.nextRelease && statistic.variants.nextRelease !== '') {
+      moment(statistic.variants.nextRelease).format('DD. MMMM YYYY')
+    }
+  }
+
   const model = {
-    title: page.displayName,
-    statistic
+    title,
+    previousRelease,
+    nextRelease
   }
 
   const body = render(view, model)

--- a/src/main/resources/site/parts/statistics/statistics.html
+++ b/src/main/resources/site/parts/statistics/statistics.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-12 col-lg-6 p-0">
             <div class="titles-dates-wrapper">
-                <h1 data-th-text="${title}" />
+                <h1 class="mb-5 mt-4" data-th-text="${title}" />
                 <p>
                     <span class="font-weight-bold" data-th-utext="${updated}" />
                     <span data-th-text="${previousRelease}" />

--- a/src/main/resources/site/parts/statistics/statistics.html
+++ b/src/main/resources/site/parts/statistics/statistics.html
@@ -4,11 +4,11 @@
             <div class="titles-dates-wrapper">
                 <h1 data-th-text="${title}" />
                 <p>
-                    <span class="font-weight-bold">Oppdatert: </span>
+                    <span class="font-weight-bold" data-th-utext="${updated}" />
                     <span data-th-text="${previousRelease}" />
                 </p>
                 <p>
-                    <span class="font-weight-bold">Neste oppdatering: </span>
+                    <span class="font-weight-bold" data-th-utext="${nextUpdate}" />
                     <span data-th-text="${nextRelease}" />
                 </p>
             </div>

--- a/src/main/resources/site/parts/statistics/statistics.html
+++ b/src/main/resources/site/parts/statistics/statistics.html
@@ -3,7 +3,7 @@
         <div class="col-12 col-lg-6 p-0">
             <div class="titles-dates-wrapper">
                 <h1 class="mb-5 mt-4" data-th-text="${title}" />
-                <p>
+                <p class="mb-2">
                     <span class="font-weight-bold" data-th-utext="${updated}" />
                     <span data-th-text="${previousRelease}" />
                 </p>

--- a/src/main/resources/site/parts/statistics/statistics.html
+++ b/src/main/resources/site/parts/statistics/statistics.html
@@ -2,24 +2,15 @@
     <div class="row">
         <div class="col-12 col-lg-6 p-0">
             <div class="titles-dates-wrapper">
-                <!-- Show default display name if there is no selected statistics page-->
-                <div data-th-if="!${statistic}">
-                    <h1 data-th-if="${title}" data-th-text="${title}" />
-                </div>
-
-                <div data-th-if="${statistic}">
-                    <h1 data-th-if="${statistic.name}" data-th-text="${statistic.name}" />
-                    <p>
-                        <span class="font-weight-bold">Oppdatert: </span>
-                        <span data-th-if="!${statistic.variants.nextRelease}">Ikke tilgjengelig</span>
-                        <span data-th-if="${statistic.variants.previousRelease}" data-th-text="${statistic.variants.previousRelease}" />
-                    </p>
-                    <p>
-                        <span class="font-weight-bold">Neste oppdatering: </span>
-                        <span data-th-if="!${statistic.variants.nextRelease}">Foreløpig ikke fastsatt</span>
-                        <span data-th-if="${statistic.variants.nextRelease}" data-th-text="${statistic.variants.nextRelease}" />
-                    </p>
-                </div>
+                <h1 data-th-text="${title}" />
+                <p>
+                    <span class="font-weight-bold">Oppdatert: </span>
+                    <span data-th-text="${previousRelease}" />
+                </p>
+                <p>
+                    <span class="font-weight-bold">Neste oppdatering: </span>
+                    <span data-th-text="${nextRelease}" />
+                </p>
             </div>
         </div>
     </div>

--- a/src/main/resources/site/parts/statistics/statistics.html
+++ b/src/main/resources/site/parts/statistics/statistics.html
@@ -2,23 +2,24 @@
     <div class="row">
         <div class="col-12 col-lg-6 p-0">
             <div class="titles-dates-wrapper">
-                <div data-th-if="${statistic}">
-                    <h1 data-th-if="${statistic.name}" data-th-text="${statistic.name}" />
-                </div>
+                <!-- Show default display name if there is no selected statistics page-->
                 <div data-th-if="!${statistic}">
                     <h1 data-th-if="${title}" data-th-text="${title}" />
                 </div>
 
-                <!-- TODO: Add conditional statement -->
-                <p>
-                    <span class="font-weight-bold">Oppdatert: </span>
-                    <!-- TODO: Replace with data from statreg -->
-                </p>
-                <p>
-                    <span class="font-weight-bold">Neste oppdatering: </span>
-                    <!-- TODO: Add conditional statement -->
-                    <span>Foreløpig ikke fastsatt</span>
-                </p>
+                <div data-th-if="${statistic}">
+                    <h1 data-th-if="${statistic.name}" data-th-text="${statistic.name}" />
+                    <p>
+                        <span class="font-weight-bold">Oppdatert: </span>
+                        <span data-th-if="!${statistic.variants.nextRelease}">Ikke tilgjengelig</span>
+                        <span data-th-if="${statistic.variants.previousRelease}" data-th-text="${statistic.variants.previousRelease}" />
+                    </p>
+                    <p>
+                        <span class="font-weight-bold">Neste oppdatering: </span>
+                        <span data-th-if="!${statistic.variants.nextRelease}">Foreløpig ikke fastsatt</span>
+                        <span data-th-if="${statistic.variants.nextRelease}" data-th-text="${statistic.variants.nextRelease}" />
+                    </p>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/site/parts/statistics/statistics.html
+++ b/src/main/resources/site/parts/statistics/statistics.html
@@ -1,25 +1,24 @@
 <section class="xp-part statistics container-fluid">
     <div class="row">
-        <div class="col-12">
-            <h1 data-th-if="${title}" data-th-text="${title}" />
-            <div data-th-if="${statistic}" class="statistic">
-                <span data-th-if="${statistic.shortName}" class="shortName" data-th-text="${statistic.shortName}" />
-                <span data-th-if="${statistic.name}" class="name" data-th-text="${statistic.name}" />
-            </div>
-            <div data-th-if="${publications}" class="publicationsTable">
-                <h4>Publikasjoner</h4>
-                <div class="publication header">
-                    <span data-th-text="ID">ID</span>
-                    <span data-th-text="Variant">Variant</span>
-                    <span data-th-text="Status">Status</span>
-                    <span data-th-text="Endret">Modified</span>
+        <div class="col-12 col-lg-6 p-0">
+            <div class="titles-dates-wrapper">
+                <div data-th-if="${statistic}">
+                    <h1 data-th-if="${statistic.name}" data-th-text="${statistic.name}" />
                 </div>
-                <div data-th-each="pub: ${publications}" class="publication">
-                    <span data-th-text="${pub.id}">ID</span>
-                    <span data-th-text="${pub.variant}">VARIANT</span>
-                    <span data-th-text="${pub.status}">STATUS</span>
-                    <span data-th-text="${pub.modifiedTime}">MODIFIED TIME</span>
+                <div data-th-if="!${statistic}">
+                    <h1 data-th-if="${title}" data-th-text="${title}" />
                 </div>
+
+                <!-- TODO: Add conditional statement -->
+                <p>
+                    <span class="font-weight-bold">Oppdatert: </span>
+                    <!-- TODO: Replace with data from statreg -->
+                </p>
+                <p>
+                    <span class="font-weight-bold">Neste oppdatering: </span>
+                    <!-- TODO: Add conditional statement -->
+                    <span>Foreløpig ikke fastsatt</span>
+                </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Displays statistics name, previous release and next release dates from Statreg.
- Shows default display name and generic text for dates if no statistics are selected in the content selector.
- Text that can be translated has been added to phrases. Those phrases are used in the statistics part.