### PR TITLE
MIMIR-659: correct order of x-axis categories

### DIFF
--- a/src/main/resources/lib/highcharts/config.es6
+++ b/src/main/resources/lib/highcharts/config.es6
@@ -191,6 +191,7 @@ export const createConfig = (highchartData, displayName) => ({
     type: highchartData.yAxisType || 'linear'
   },
   xAxis: {
+    reversed: false,
     title: {
       style,
       text: highchartData.xAxisTitle || '',


### PR DESCRIPTION
Set `reversed` to `false` for x-axis categories