### PR TITLE
Mimir 536 article archive field adjustment

### DIFF
--- a/src/main/resources/site/content-types/articleArchive/articleArchive.ts
+++ b/src/main/resources/site/content-types/articleArchive/articleArchive.ts
@@ -15,12 +15,12 @@ export interface ArticleArchive {
   image?: string;
 
   /**
+   * Fritekst
+   */
+  freeText?: string;
+
+  /**
    * ISSN-nummer
    */
   issnNumber?: string;
-
-  /**
-   * Informasjonstekst
-   */
-  infoText?: string;
 }

--- a/src/main/resources/site/content-types/articleArchive/articleArchive.ts
+++ b/src/main/resources/site/content-types/articleArchive/articleArchive.ts
@@ -20,7 +20,7 @@ export interface ArticleArchive {
   issnNumber?: string;
 
   /**
-   * URL
+   * Informasjonstekst
    */
-  url?: string;
+  infoText?: string;
 }

--- a/src/main/resources/site/content-types/articleArchive/articleArchive.xml
+++ b/src/main/resources/site/content-types/articleArchive/articleArchive.xml
@@ -15,12 +15,13 @@
             <occurrences minimum="0" maximum="1" />
         </input>
 
-        <input name="issnNumber" type="TextLine">
-            <label>ISSN-nummer</label>
+        <input name="freeText" type="HtmlArea">
+            <label>Fritekst</label>
             <occurrences minimum="0" maximum="1" />
         </input>
-        <input name="infoText" type="HtmlArea">
-            <label>Informasjonstekst</label>
+
+        <input name="issnNumber" type="TextLine">
+            <label>ISSN-nummer</label>
             <occurrences minimum="0" maximum="1" />
         </input>
     </form>

--- a/src/main/resources/site/content-types/articleArchive/articleArchive.xml
+++ b/src/main/resources/site/content-types/articleArchive/articleArchive.xml
@@ -19,8 +19,8 @@
             <label>ISSN-nummer</label>
             <occurrences minimum="0" maximum="1" />
         </input>
-        <input name="url" type="TextLine">
-            <label>URL</label>
+        <input name="infoText" type="HtmlArea">
+            <label>Informasjonstekst</label>
             <occurrences minimum="0" maximum="1" />
         </input>
     </form>


### PR DESCRIPTION
- Replaces the previously 'URL' text field with a html area renamed to 'Fritekst'.
- Moves the free text field higher, above ISSN, to follow the flow of the visual layout.