### PR TITLE
Adds Mabl end-to-end testing as part of QA deploy pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -89,7 +89,8 @@ steps:
         {{else}}
           build {{build.number}} failed. {{build.author}} triggered the build. Maybe do a fix? Here's the failed build: {{build.link}}
         {{/success}}
-    when: status [success, failure]
+    when:
+      status: [success, failure]
 ---
 kind: pipeline
 type: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -67,6 +67,16 @@ steps:
         from_secret: ssb-xp7q-pass
     commands:
       - enonic app install --file build/libs/*.jar
+  - name: mabl end-to-end test
+    image: enonic/enonic-ci:7.1-node
+    environment:
+      MABL_API_KEY:
+        from_secret: mabl-api-key
+      MABL_APP_ID:
+        from_secret: mabl-application-id
+    commands:
+      - npm install -g @mablhq/mabl-cli
+      - mabl deployments create --api-key $MABL_API_KEY --application-id $MABL_APP_ID  --labels MIMIR --await-completion
 ---
 kind: pipeline
 type: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,6 +77,19 @@ steps:
     commands:
       - npm install -g @mablhq/mabl-cli
       - mabl deployments create --api-key $MABL_API_KEY --application-id $MABL_APP_ID  --labels MIMIR --await-completion
+  - name: slack
+    image: plugins/slack
+    settings:
+      webhook:
+        from_secret: slack_webhook_mimir_utv
+      channel: mimir_utv
+      template: >
+        {{#success build.status}}
+          build {{build.number}} deploy to QA succeeded. Good job.
+        {{else}}
+          build {{build.number}} failed. {{build.author}} triggered the build. Maybe do a fix? Here's the failed build: {{build.link}}
+        {{/success}}
+    when: status [success, failure]
 ---
 kind: pipeline
 type: docker


### PR DESCRIPTION
Testing Mabl integration with Drone, building on QA deploy run 