### PR TITLE
MIMIR-742 indentation statistics page

### DIFF
--- a/src/main/resources/assets/styles/_omStatistikken.scss
+++ b/src/main/resources/assets/styles/_omStatistikken.scss
@@ -1,0 +1,27 @@
+.part-om-statistikken {
+  padding: 0;
+
+  .title-wrapper {
+    font-family: $font-roboto-condensed-bold;
+    margin-bottom: $spacer * 2;
+
+    @include media-breakpoint-down(md) {
+      padding: 0;
+    }
+  }
+
+  .ingress-wrapper {
+    margin-bottom: $spacer * 2;
+    font-size: 20px;
+
+    @include media-breakpoint-down(md) {
+      padding: 0;
+    }
+  }
+
+  .om-statistikken-accordion {
+    @include media-breakpoint-down(md) {
+      padding: 0;
+    }
+  }
+}

--- a/src/main/resources/assets/styles/_relatedArticles.scss
+++ b/src/main/resources/assets/styles/_relatedArticles.scss
@@ -2,4 +2,10 @@
   & .row:first-of-type {
     margin-top: $spacer * 1.5;
   }
+
+  .ssb-card {
+    @include media-breakpoint-down(md) {
+      padding: 0;
+    }
+  }
 }

--- a/src/main/resources/assets/styles/_statbankBox.scss
+++ b/src/main/resources/assets/styles/_statbankBox.scss
@@ -19,6 +19,10 @@
         margin-bottom: 10px;
       }
     }
+
+    @include media-breakpoint-down(md) {
+      padding: 0;
+    }
   }
 
   .content {
@@ -55,5 +59,4 @@
       margin-left: 20px;
     }
   }
-
 }

--- a/src/main/resources/assets/styles/_table.scss
+++ b/src/main/resources/assets/styles/_table.scss
@@ -30,8 +30,7 @@
 
   @include media-breakpoint-down(md) {
     width: 95%;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 0;
 
     caption > img {
       display: block;

--- a/src/main/resources/assets/styles/main.scss
+++ b/src/main/resources/assets/styles/main.scss
@@ -58,6 +58,7 @@ $container-max-widths: (
 @import "./articleArchive";
 @import "./table";
 @import "./statbankLinkList";
+@import "./omStatistikken";
 
 body {
   -moz-osx-font-smoothing: grayscale;

--- a/src/main/resources/site/parts/omStatistikken/omStatistikken.html
+++ b/src/main/resources/site/parts/omStatistikken/omStatistikken.html
@@ -1,6 +1,7 @@
 <section id="om-statistikken" class="xp-part part-om-statistikken container-fluid">
-    <h2 data-th-text="${label}?: 'Om statistikken'" class="roboto-condensed-bold mb-md-4 pb-md-2 bt-6"></h2>
-    <p class="ingress-wrapper searchabletext ingress col-lg-6 pl-0 mb-4" data-th-if="${ingress}" data-th-text="${ingress}"></p>
-    <div class="col-lg-7 pl-0" data-th-id="${omStatistikkenId}"></div>
+    <div class="row">
+        <h2 data-th-text="${label}?: 'Om statistikken'" class="title-wrapper col-12"></h2>
+        <p class="ingress-wrapper searchabletext col-lg-6" data-th-if="${ingress}" data-th-text="${ingress}"></p>
+        <div class="om-statistikken-accordion col-lg-7" data-th-id="${omStatistikkenId}"></div>
+    </div>
 </section>
-

--- a/src/main/resources/site/parts/statbankBox/statbankBox.html
+++ b/src/main/resources/site/parts/statbankBox/statbankBox.html
@@ -1,14 +1,14 @@
-<!--<section class="xp-part part-statbank-box container" data-th-id="${statbankBoxId}"></section>-->
-
-<section class="xp-part part-statbank-box container" data-th-id="${statbankBoxId}">
-    <a class="statbank-link col-lg-7" data-th-href="${href}">
-        <div class="content">
-            <div data-th-if="${statbankIcon}" class="icon-wrapper">
-                <img  data-th-src="${statbankIcon}" data-th-alt="'Statbank logo'"/>
+<section class="xp-part part-statbank-box container-fluid p-0" data-th-id="${statbankBoxId}">
+    <div class="row">
+        <a class="statbank-link col-lg-7" data-th-href="${href}">
+            <div class="content">
+                <div data-th-if="${statbankIcon}" class="icon-wrapper">
+                    <img  data-th-src="${statbankIcon}" data-th-alt="'Statbank logo'"/>
+                </div>
+                <div data-th-if="${title}" class="title-wrapper">
+                    <h3 class="title" data-th-text="${title}">Finn flere tall i Statistikkbanken</h3>
+                </div>
             </div>
-            <div data-th-if="${title}" class="title-wrapper">
-                <h3 class="title" data-th-text="${title}">Finn flere tall i Statistikkbanken</h3>
-            </div>
-        </div>
-    </a>
+        </a>
+    </div>
 </section>


### PR DESCRIPTION
- Fixes indentation for parts: omStatistikken, relatedArticles, statBankBox, and table.
- Nests some parts in rows and columns which fixes the indentation on desktop, whilst a padding/margin 0 for all parts fixes the issue for mobile.