### PR TITLE
Mimir 719 fixes table download csv PART 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1393,12 +1393,6 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
-    "@types/raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
-      "optional": true
-    },
     "@types/ramda": {
       "version": "0.27.14",
       "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.14.tgz",
@@ -1706,11 +1700,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1722,35 +1711,11 @@
       "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true
     },
-    "acorn-globals": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-      "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
-      "requires": {
-        "acorn": "^2.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
-        }
-      }
-    },
     "acorn-jsx": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
-    },
-    "adler-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
-      "integrity": "sha1-aj5r8KY5ALoVZSgIyxXGgT0aXyU=",
-      "requires": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
-      }
     },
     "ajv": {
       "version": "6.12.3",
@@ -1937,11 +1902,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-    },
-    "array-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -2904,12 +2864,6 @@
         }
       }
     },
-    "base64-arraybuffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-      "optional": true
-    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -3126,11 +3080,6 @@
         "node-releases": "^1.1.60"
       }
     },
-    "btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
-    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -3273,28 +3222,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001112.tgz",
       "integrity": "sha512-J05RTQlqsatidif/38aN3PGULCLrg8OYQOlJUKbeYVzC2mGZkZLIztwRlB3MtrfLmawUmjFlNJvy/uhwniIe1Q=="
     },
-    "canvg": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.6.tgz",
-      "integrity": "sha512-eFUy8R/4DgocR93LF8lr+YUxW4PYblUe/Q1gz2osk/cI5n8AsYdassvln0D9QPhLXQ6Lx7l8hwtT8FLvOn2Ihg==",
-      "optional": true,
-      "requires": {
-        "@babel/runtime": "^7.6.3",
-        "@types/raf": "^3.4.0",
-        "core-js": "3",
-        "raf": "^3.4.1",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-          "optional": true
-        }
-      }
-    },
     "capital-case": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.3.tgz",
@@ -3310,16 +3237,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "cfb": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.0.tgz",
-      "integrity": "sha512-sXMvHsKCICVR3Naq+J556K+ExBo9n50iKl6LGarlnvuA2035uMlGA/qVrc0wQtow5P1vJEw9UyrKLCbtIKz+TQ==",
-      "requires": {
-        "adler-32": "~1.2.0",
-        "crc-32": "~1.2.0",
-        "printj": "~1.1.2"
-      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -3549,22 +3466,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "codepage": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
-      "integrity": "sha1-jL4lSBMjVZ19MHVxsP/5HnodL5k=",
-      "requires": {
-        "commander": "~2.14.1",
-        "exit-on-epipe": "~1.0.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
-        }
-      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -3819,15 +3720,6 @@
         }
       }
     },
-    "crc-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
-      "requires": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
-      }
-    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -3935,15 +3827,6 @@
       "requires": {
         "postcss": "^7.0.1",
         "timsort": "^0.3.0"
-      }
-    },
-    "css-line-break": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.1.1.tgz",
-      "integrity": "sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==",
-      "optional": true,
-      "requires": {
-        "base64-arraybuffer": "^0.2.0"
       }
     },
     "css-loader": {
@@ -4128,19 +4011,6 @@
         }
       }
     },
-    "cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-    },
-    "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "requires": {
-        "cssom": "0.3.x"
-      }
-    },
     "csstype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
@@ -4197,7 +4067,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -4370,12 +4241,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-    },
-    "dompurify": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.14.tgz",
-      "integrity": "sha512-oqcjyCLHLjWugZ6VwK0YfmRND/DFy/CuZhdasmymMfnxbzaaQxBSA1ATZIXWESGDj/nvq1vKLmRa7rTdbGgrmQ==",
-      "optional": true
     },
     "domutils": {
       "version": "1.7.0",
@@ -4575,11 +4440,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
     "es6-set-and-map": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/es6-set-and-map/-/es6-set-and-map-1.0.5.tgz",
@@ -4608,26 +4468,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
-        }
-      }
     },
     "eslint": {
       "version": "6.8.0",
@@ -4938,7 +4778,8 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -4965,11 +4806,6 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -5190,7 +5026,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "feather-icons": {
       "version": "4.28.0",
@@ -5244,11 +5081,6 @@
         "loader-utils": "^1.0.2",
         "schema-utils": "^1.0.0"
       }
-    },
-    "file-saver": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
-      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -5414,11 +5246,6 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
-    },
-    "frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -5840,11 +5667,6 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
-    "html2canvas": {
-      "version": "0.5.0-beta4",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-0.5.0-beta4.tgz",
-      "integrity": "sha1-goLGKsX9eBaPVwK15IdxV8qT854="
-    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5870,6 +5692,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -6463,37 +6286,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
-    "jsdom": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.5.0.tgz",
-      "integrity": "sha1-1Nj12/J2hjW2KmKCO5R89wcevJg=",
-      "requires": {
-        "abab": "^1.0.0",
-        "acorn": "^2.4.0",
-        "acorn-globals": "^1.0.4",
-        "array-equal": "^1.0.0",
-        "cssom": ">= 0.3.0 < 0.4.0",
-        "cssstyle": ">= 0.2.34 < 0.3.0",
-        "escodegen": "^1.6.1",
-        "iconv-lite": "^0.4.13",
-        "nwmatcher": ">= 1.3.7 < 2.0.0",
-        "parse5": "^1.5.1",
-        "request": "^2.55.0",
-        "sax": "^1.1.4",
-        "symbol-tree": ">= 3.1.0 < 4.0.0",
-        "tough-cookie": "^2.2.0",
-        "webidl-conversions": "^3.0.1",
-        "whatwg-url": "^2.0.1",
-        "xml-name-validator": ">= 2.0.1 < 3.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
-        }
-      }
-    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -6541,118 +6333,6 @@
         "node-fetch": "^2.6.0"
       }
     },
-    "jspdf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.1.0.tgz",
-      "integrity": "sha512-NQygqZEKhSw+nExySJxB72Ge/027YEyIM450Vh/hgay/H9cgZNnkXXOQPRspe9EuCW4sq92zg8hpAXyyBdnaIQ==",
-      "requires": {
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
-        "canvg": "^3.0.6",
-        "core-js": "^3.6.0",
-        "dompurify": "^2.0.12",
-        "html2canvas": "^1.0.0-rc.5"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-          "optional": true
-        },
-        "html2canvas": {
-          "version": "1.0.0-rc.7",
-          "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-rc.7.tgz",
-          "integrity": "sha512-yvPNZGejB2KOyKleZspjK/NruXVQuowu8NnV2HYG7gW7ytzl+umffbtUI62v2dCHQLDdsK6HIDtyJZ0W3neerA==",
-          "optional": true,
-          "requires": {
-            "css-line-break": "1.1.1"
-          }
-        }
-      }
-    },
-    "jspdf-autotable": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-2.0.17.tgz",
-      "integrity": "sha1-usPRFK4S1E4NeXVjTROZ+GZxbHc=",
-      "requires": {
-        "jspdf": "^1.0.272"
-      },
-      "dependencies": {
-        "base64-arraybuffer": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-        },
-        "canvg": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/canvg/-/canvg-1.5.3.tgz",
-          "integrity": "sha512-7Gn2IuQzvUQWPIuZuFHrzsTM0gkPz2RRT9OcbdmA03jeKk8kltrD8gqUzNX15ghY/4PV5bbe5lmD6yDLDY6Ybg==",
-          "requires": {
-            "jsdom": "^8.1.0",
-            "rgbcolor": "^1.0.1",
-            "stackblur-canvas": "^1.4.1",
-            "xmldom": "^0.1.22"
-          },
-          "dependencies": {
-            "stackblur-canvas": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-1.4.1.tgz",
-              "integrity": "sha1-hJqm+UsnL/JvZHH6QTDtH35HlVs="
-            }
-          }
-        },
-        "css-line-break": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.0.1.tgz",
-          "integrity": "sha1-GfIGOjPpX7KDG4ZEbAuAwYivRQo=",
-          "requires": {
-            "base64-arraybuffer": "^0.1.5"
-          }
-        },
-        "file-saver": {
-          "version": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
-          "from": "github:eligrey/FileSaver.js#1.3.8"
-        },
-        "html2canvas": {
-          "version": "1.0.0-alpha.12",
-          "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-alpha.12.tgz",
-          "integrity": "sha1-OxmS48mz9WBjw1/WIElPN+uohRM=",
-          "requires": {
-            "css-line-break": "1.0.1"
-          }
-        },
-        "jspdf": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-1.5.3.tgz",
-          "integrity": "sha512-J9X76xnncMw+wIqb15HeWfPMqPwYxSpPY8yWPJ7rAZN/ZDzFkjCSZObryCyUe8zbrVRNiuCnIeQteCzMn7GnWw==",
-          "requires": {
-            "canvg": "1.5.3",
-            "file-saver": "github:eligrey/FileSaver.js#1.3.8",
-            "html2canvas": "1.0.0-alpha.12",
-            "omggif": "1.0.7",
-            "promise-polyfill": "8.1.0",
-            "stackblur-canvas": "2.2.0"
-          },
-          "dependencies": {
-            "file-saver": {
-              "version": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
-              "from": "github:eligrey/FileSaver.js#1.3.8"
-            }
-          }
-        },
-        "stackblur-canvas": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.2.0.tgz",
-          "integrity": "sha512-5Gf8dtlf8k6NbLzuly2NkGrkS/Ahh+I5VUjO7TnFizdJtgpfpLLEdQlLe9umbcnZlitU84kfYjXE67xlSXfhfQ=="
-        },
-        "xmldom": {
-          "version": "0.1.31",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-          "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
-        }
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6696,6 +6376,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -7470,11 +7151,6 @@
       "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
       "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
     },
-    "nwmatcher": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
-    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -7603,11 +7279,6 @@
         "has": "^1.0.3"
       }
     },
-    "omggif": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.7.tgz",
-      "integrity": "sha1-WdLuywJj3oRjWz/riHwMmXPx5J0="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7629,6 +7300,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -7776,11 +7448,6 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
-    },
-    "parse5": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
     },
     "pascal-case": {
       "version": "3.1.1",
@@ -8503,7 +8170,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -8515,11 +8183,6 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "optional": true
-    },
-    "printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
     },
     "prismjs": {
       "version": "1.21.0",
@@ -8555,11 +8218,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-    },
-    "promise-polyfill": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
-      "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA=="
     },
     "prop-types": {
       "version": "15.7.2",
@@ -8683,15 +8341,6 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
-    },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "optional": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
     },
     "ramda": {
       "version": "0.26.1",
@@ -9208,11 +8857,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
-    },
-    "rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0="
     },
     "rimraf": {
       "version": "2.7.1",
@@ -9746,14 +9390,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "requires": {
-        "frac": "~1.1.2"
-      }
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -9782,12 +9418,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
-    },
-    "stackblur-canvas": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.4.0.tgz",
-      "integrity": "sha512-Z+HixfgYV0ss3C342DxPwc+UvN1SYWqoz7Wsi3xEDWEnaBkSCL3Ey21gF4io+WlLm8/RIrSnCrDBIEcH4O+q5Q==",
-      "optional": true
     },
     "static-extend": {
       "version": "0.1.2",
@@ -10039,11 +9669,6 @@
         }
       }
     },
-    "symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
-    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -10088,20 +9713,6 @@
             "ansi-regex": "^4.1.0"
           }
         }
-      }
-    },
-    "tableexport.jquery.plugin": {
-      "version": "1.10.20",
-      "resolved": "https://registry.npmjs.org/tableexport.jquery.plugin/-/tableexport.jquery.plugin-1.10.20.tgz",
-      "integrity": "sha512-cltEQSDLn6ljLXwCir6zUXAlfIYrgo6NJa5Vmznpka//efoZTJt3FZPJeOVweO/YefL1/1SH1qBxjROOspCifw==",
-      "requires": {
-        "es6-promise": ">=4.2.4",
-        "file-saver": ">=1.2.0",
-        "html2canvas": ">=0.5.0-beta4",
-        "jquery": ">=1.9.1",
-        "jspdf": ">=1.3.4",
-        "jspdf-autotable": "2.0.14 || 2.0.17",
-        "xlsx": ">=0.12.5"
       }
     },
     "tapable": {
@@ -10275,11 +9886,6 @@
         "punycode": "^2.1.1"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -10430,6 +10036,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -10968,11 +10575,6 @@
         }
       }
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
     "webpack": {
       "version": "4.44.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
@@ -11161,15 +10763,6 @@
         }
       }
     },
-    "whatwg-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-2.0.1.tgz",
-      "integrity": "sha1-U5ayBD8CDub3BNnEXqhRnnJN5lk=",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -11191,20 +10784,11 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="
-    },
-    "word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -11275,34 +10859,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "xlsx": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.16.6.tgz",
-      "integrity": "sha512-iAPNt15C2umCx7Q6h9owZvNHRYVOImLp7Mc00uA4UhJvzjfM1OV3V7TgBXIHuawGF1G6GLXZr/r75e5jsiBefg==",
-      "requires": {
-        "adler-32": "~1.2.0",
-        "cfb": "^1.1.4",
-        "codepage": "~1.14.0",
-        "commander": "~2.17.1",
-        "crc-32": "~1.2.0",
-        "exit-on-epipe": "~1.0.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
-        }
-      }
-    },
-    "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
     },
     "xmldom": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "react4xp": "^1.1.3",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
-    "tableexport.jquery.plugin": "^1.10.20",
     "terser-webpack-plugin": "^1.4.5",
     "ts-loader": "^6.2.2",
     "typescript": "^3.9.7",

--- a/src/main/resources/assets/js/tableExport.js
+++ b/src/main/resources/assets/js/tableExport.js
@@ -1,0 +1,2200 @@
+/**
+ * @preserve tableExport.jquery.plugin
+ *
+ * Copyright (c) 2015-2020 hhurz, https://github.com/hhurz/
+ * Multi Worksheets Support, Copyright (c) 2017 hejiheji001, https://github.com/hejiheji001/
+ * Original Work, Copyright (c) 2014 Giri Raj, https://github.com/kayalshri/
+ *
+ * Licensed under the MIT License, http://opensource.org/licenses/mit-license
+ */
+
+(function($) {
+  $.fn.extend({
+    tableExport: function(options) {
+      const defaults = {
+        consoleLog: false,
+        csvEnclosure: '"',
+        csvSeparator: ',',
+        csvUseBOM: true,
+        displayTableName: false,
+        escape: false,
+        excelFileFormat: 'xlshtml', // xmlss = XML Spreadsheet 2003 file format (XMLSS), xlshtml = Excel 2000 html format
+        excelstyles: [], // e.g. ['border-bottom', 'border-top', 'border-left', 'border-right']
+        fileName: 'tableExport',
+        htmlContent: false,
+        ignoreColumn: [],
+        ignoreRow: [],
+        jsonScope: 'all', // head, data, all
+        jspdf: {
+          orientation: 'p',
+          unit: 'pt',
+          format: 'a4', // jspdf page format or 'bestfit' for autmatic paper format selection
+          margins: {
+            left: 20,
+            right: 10,
+            top: 10,
+            bottom: 10
+          },
+          autotable: {
+            styles: {
+              cellPadding: 2,
+              rowHeight: 12,
+              fontSize: 8,
+              fillColor: 255, // color value or 'inherit' to use css background-color from html table
+              textColor: 50, // color value or 'inherit' to use css color from html table
+              fontStyle: 'normal', // normal, bold, italic, bolditalic or 'inherit' to use css font-weight and fonst-style from html table
+              overflow: 'ellipsize', // visible, hidden, ellipsize or linebreak
+              halign: 'left', // left, center, right
+              valign: 'middle' // top, middle, bottom
+            },
+            headerStyles: {
+              fillColor: [52, 73, 94],
+              textColor: 255,
+              fontStyle: 'bold',
+              halign: 'center'
+            },
+            alternateRowStyles: {
+              fillColor: 245
+            },
+            tableExport: {
+              onAfterAutotable: null,
+              onBeforeAutotable: null,
+              onAutotableText: null,
+              onTable: null,
+              outputImages: true
+            }
+          }
+        },
+        numbers: {
+          html: {
+            decimalMark: '.',
+            thousandsSeparator: ','
+          },
+          output: // set to false to not format numbers in exported output
+                        {
+                          decimalMark: '.',
+                          thousandsSeparator: ','
+                        }
+        },
+        onCellData: null,
+        onCellHtmlData: null,
+        onMsoNumberFormat: null, // Excel 2000 html format only. See readme.md for more information about msonumberformat
+        outputMode: 'file', // 'file', 'string', 'base64' or 'window' (experimental)
+        pdfmake: {
+          enabled: false, // true: use pdfmake instead of jspdf and jspdf-autotable (experimental)
+          docDefinition: {
+            pageOrientation: 'portrait', // 'portrait' or 'landscape'
+            defaultStyle: {
+              font: 'Roboto' // default is 'Roboto', for arabic font set this option to 'Mirza' and include mirza_fonts.js
+            }
+          },
+          fonts: {}
+        },
+        tbodySelector: 'tr',
+        tfootSelector: 'tr', // set empty ('') to prevent export of tfoot rows
+        theadSelector: 'tr',
+        tableName: 'myTableName',
+        type: 'csv', // 'csv', 'tsv', 'txt', 'sql', 'json', 'xml', 'excel', 'doc', 'png' or 'pdf'
+        worksheetName: 'Worksheet'
+      }
+
+      const FONT_ROW_RATIO = 1.15
+      const el = this
+      let DownloadEvt = null
+      let $hrows = []
+      let $rows = []
+      let rowIndex = 0
+      const rowspans = []
+      let trData = ''
+      let colNames = []
+      let blob
+
+      $.extend(true, defaults, options)
+
+      colNames = GetColumnNames(el)
+
+      if (defaults.type == 'csv' || defaults.type == 'tsv' || defaults.type == 'txt') {
+        let csvData = ''
+        let rowlength = 0
+        rowIndex = 0
+
+        function csvString(cell, rowIndex, colIndex) {
+          let result = ''
+
+          if (cell !== null) {
+            const dataString = parseString(cell, rowIndex, colIndex)
+
+            const csvValue = (dataString === null || dataString === '') ? '' : dataString.toString()
+
+            if (defaults.type == 'tsv') {
+              if (dataString instanceof Date) {
+                result = dataString.toLocaleString()
+              }
+
+              // According to http://www.iana.org/assignments/media-types/text/tab-separated-values
+              // are fields that contain tabs not allowable in tsv encoding
+              result = replaceAll(csvValue, '\t', ' ')
+            } else {
+              // Takes a string and encapsulates it (by default in double-quotes) if it
+              // contains the csv field separator, spaces, or linebreaks.
+              if (dataString instanceof Date) {
+                result = defaults.csvEnclosure + dataString.toLocaleString() + defaults.csvEnclosure
+              } else {
+                result = replaceAll(csvValue, defaults.csvEnclosure, defaults.csvEnclosure + defaults.csvEnclosure)
+
+                if (result.indexOf(defaults.csvSeparator) >= 0 || /[\r\n ]/g.test(result)) {
+                  result = defaults.csvEnclosure + result + defaults.csvEnclosure
+                }
+              }
+            }
+          }
+
+          return result
+        }
+
+        const CollectCsvData = function($rows, rowselector, length) {
+          $rows.each(function() {
+            trData = ''
+            ForEachVisibleCell(this, rowselector, rowIndex, length + $rows.length,
+              function(cell, row, col) {
+                trData += csvString(cell, row, col) + (defaults.type == 'tsv' ? '\t' : defaults.csvSeparator)
+              })
+            trData = $.trim(trData).substring(0, trData.length - 1)
+            if (trData.length > 0) {
+              if (csvData.length > 0) {
+                csvData += '\n'
+              }
+
+              csvData += trData
+            }
+            rowIndex++
+          })
+
+          return $rows.length
+        }
+
+        rowlength += CollectCsvData($(el).find('thead').first()
+          .find(defaults.theadSelector), 'th,td', rowlength)
+        $(el).find('tbody').each(function() {
+          rowlength += CollectCsvData($(this).find(defaults.tbodySelector), 'td,th', rowlength)
+        })
+        if (defaults.tfootSelector.length) {
+          CollectCsvData($(el).find('tfoot').first()
+            .find(defaults.tfootSelector), 'td,th', rowlength)
+        }
+
+        csvData += '\n'
+
+        // output
+        if (defaults.consoleLog === true) {
+          console.log(csvData)
+        }
+
+        if (defaults.outputMode === 'string') {
+          return csvData
+        }
+
+        if (defaults.outputMode === 'base64') {
+          return base64encode(csvData)
+        }
+
+        if (defaults.outputMode === 'window') {
+          downloadFile(false, 'data:text/' + (defaults.type == 'csv' ? 'csv' : 'plain') + ';charset=utf-8,', csvData)
+          return
+        }
+
+        try {
+          blob = new Blob([csvData], {
+            type: 'text/' + (defaults.type == 'csv' ? 'csv' : 'plain') + ';charset=utf-8'
+          })
+          saveAs(blob, defaults.fileName + '.' + defaults.type, (defaults.type != 'csv' || defaults.csvUseBOM === false))
+        } catch (e) {
+          downloadFile(defaults.fileName + '.' + defaults.type,
+            'data:text/' + (defaults.type == 'csv' ? 'csv' : 'plain') + ';charset=utf-8,' + ((defaults.type == 'csv' && defaults.csvUseBOM) ? '\ufeff' : ''),
+            csvData)
+        }
+      } else if (defaults.type == 'sql') {
+        // Header
+        rowIndex = 0
+        let tdData = 'INSERT INTO `' + defaults.tableName + '` ('
+        $hrows = $(el).find('thead').first()
+          .find(defaults.theadSelector)
+        $hrows.each(function() {
+          ForEachVisibleCell(this, 'th,td', rowIndex, $hrows.length,
+            function(cell, row, col) {
+              tdData += "'" + parseString(cell, row, col) + "',"
+            })
+          rowIndex++
+          tdData = $.trim(tdData)
+          tdData = $.trim(tdData).substring(0, tdData.length - 1)
+        })
+        tdData += ') VALUES '
+        // Row vs Column
+        $(el).find('tbody').each(function() {
+          $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+        })
+        if (defaults.tfootSelector.length) {
+          $rows.push.apply($rows, $(el).find('tfoot').find(defaults.tfootSelector))
+        }
+        $($rows).each(function() {
+          trData = ''
+          ForEachVisibleCell(this, 'td,th', rowIndex, $hrows.length + $rows.length,
+            function(cell, row, col) {
+              trData += "'" + parseString(cell, row, col) + "',"
+            })
+          if (trData.length > 3) {
+            tdData += '(' + trData
+            tdData = $.trim(tdData).substring(0, tdData.length - 1)
+            tdData += '),'
+          }
+          rowIndex++
+        })
+
+        tdData = $.trim(tdData).substring(0, tdData.length - 1)
+        tdData += ';'
+
+        // output
+        if (defaults.consoleLog === true) {
+          console.log(tdData)
+        }
+
+        if (defaults.outputMode === 'string') {
+          return tdData
+        }
+
+        if (defaults.outputMode === 'base64') {
+          return base64encode(tdData)
+        }
+
+        try {
+          blob = new Blob([tdData], {
+            type: 'text/plain;charset=utf-8'
+          })
+          saveAs(blob, defaults.fileName + '.sql')
+        } catch (e) {
+          downloadFile(defaults.fileName + '.sql',
+            'data:application/sql;charset=utf-8,',
+            tdData)
+        }
+      } else if (defaults.type == 'json') {
+        const jsonHeaderArray = []
+        $hrows = $(el).find('thead').first()
+          .find(defaults.theadSelector)
+        $hrows.each(function() {
+          const jsonArrayTd = []
+
+          ForEachVisibleCell(this, 'th,td', rowIndex, $hrows.length,
+            function(cell, row, col) {
+              jsonArrayTd.push(parseString(cell, row, col))
+            })
+          jsonHeaderArray.push(jsonArrayTd)
+        })
+
+        const jsonArray = []
+        $(el).find('tbody').each(function() {
+          $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+        })
+        if (defaults.tfootSelector.length) {
+          $rows.push.apply($rows, $(el).find('tfoot').find(defaults.tfootSelector))
+        }
+        $($rows).each(function() {
+          const jsonObjectTd = {}
+
+          let colIndex = 0
+          ForEachVisibleCell(this, 'td,th', rowIndex, $hrows.length + $rows.length,
+            function(cell, row, col) {
+              if (jsonHeaderArray.length) {
+                jsonObjectTd[jsonHeaderArray[jsonHeaderArray.length - 1][colIndex]] = parseString(cell, row, col)
+              } else {
+                jsonObjectTd[colIndex] = parseString(cell, row, col)
+              }
+              colIndex++
+            })
+          if ($.isEmptyObject(jsonObjectTd) === false) {
+            jsonArray.push(jsonObjectTd)
+          }
+
+          rowIndex++
+        })
+
+        let sdata = ''
+
+        if (defaults.jsonScope == 'head') {
+          sdata = JSON.stringify(jsonHeaderArray)
+        } else if (defaults.jsonScope == 'data') {
+          sdata = JSON.stringify(jsonArray)
+        } else // all
+        {
+          sdata = JSON.stringify({
+            header: jsonHeaderArray,
+            data: jsonArray
+          })
+        }
+
+        if (defaults.consoleLog === true) {
+          console.log(sdata)
+        }
+
+        if (defaults.outputMode === 'string') {
+          return sdata
+        }
+
+        if (defaults.outputMode === 'base64') {
+          return base64encode(sdata)
+        }
+
+        try {
+          blob = new Blob([sdata], {
+            type: 'application/json;charset=utf-8'
+          })
+          saveAs(blob, defaults.fileName + '.json')
+        } catch (e) {
+          downloadFile(defaults.fileName + '.json',
+            'data:application/json;charset=utf-8;base64,',
+            sdata)
+        }
+      } else if (defaults.type === 'xml') {
+        rowIndex = 0
+        var xml = '<?xml version="1.0" encoding="utf-8"?>'
+        xml += '<tabledata><fields>'
+
+        // Header
+        $hrows = $(el).find('thead').first()
+          .find(defaults.theadSelector)
+        $hrows.each(function() {
+          ForEachVisibleCell(this, 'th,td', rowIndex, $hrows.length,
+            function(cell, row, col) {
+              xml += '<field>' + parseString(cell, row, col) + '</field>'
+            })
+          rowIndex++
+        })
+        xml += '</fields><data>'
+
+        // Row Vs Column
+        let rowCount = 1
+        $(el).find('tbody').each(function() {
+          $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+        })
+        if (defaults.tfootSelector.length) {
+          $rows.push.apply($rows, $(el).find('tfoot').find(defaults.tfootSelector))
+        }
+        $($rows).each(function() {
+          let colCount = 1
+          trData = ''
+          ForEachVisibleCell(this, 'td,th', rowIndex, $hrows.length + $rows.length,
+            function(cell, row, col) {
+              trData += '<column-' + colCount + '>' + parseString(cell, row, col) + '</column-' + colCount + '>'
+              colCount++
+            })
+          if (trData.length > 0 && trData != '<column-1></column-1>') {
+            xml += '<row id="' + rowCount + '">' + trData + '</row>'
+            rowCount++
+          }
+
+          rowIndex++
+        })
+        xml += '</data></tabledata>'
+
+        // output
+        if (defaults.consoleLog === true) {
+          console.log(xml)
+        }
+
+        if (defaults.outputMode === 'string') {
+          return xml
+        }
+
+        if (defaults.outputMode === 'base64') {
+          return base64encode(xml)
+        }
+
+        try {
+          blob = new Blob([xml], {
+            type: 'application/xml;charset=utf-8'
+          })
+          saveAs(blob, defaults.fileName + '.xml')
+        } catch (e) {
+          downloadFile(defaults.fileName + '.xml',
+            'data:application/xml;charset=utf-8;base64,',
+            xml)
+        }
+      } else if (defaults.type === 'excel' && defaults.excelFileFormat === 'xmlss') {
+        var $tables = $(el).filter(function() {
+          return $(this).data('tableexport-display') != 'none' &&
+                        ($(this).is(':visible') ||
+                            $(this).data('tableexport-display') == 'always')
+        })
+        const docDatas = []
+        $tables.each(function() {
+          const $table = $(this)
+          let docData = ''
+          rowIndex = 0
+          colNames = GetColumnNames(this)
+          $hrows = $table.find('thead').first().find(defaults.theadSelector)
+          docData += '<Table>'
+
+          // Header
+          let cols = 0
+          $hrows.each(function() {
+            trData = ''
+            ForEachVisibleCell(this, 'th,td', rowIndex, $hrows.length,
+              function(cell, row, col) {
+                if (cell !== null) {
+                  trData += '<Cell><Data ss:Type="String">' + parseString(cell, row, col) + '</Data></Cell>'
+                  cols++
+                }
+              })
+            if (trData.length > 0) {
+              docData += '<Row>' + trData + '</Row>'
+            }
+            rowIndex++
+          })
+
+          // Row Vs Column, support multiple tbodys
+          $rows = []
+          $table.find('tbody').each(function() {
+            $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+          })
+
+          // if (defaults.tfootSelector.length)
+          //    $rows.push.apply($rows, $table.find('tfoot').find(defaults.tfootSelector));
+
+          $($rows).each(function() {
+            const $row = $(this)
+            trData = ''
+            ForEachVisibleCell(this, 'td,th', rowIndex, $hrows.length + $rows.length,
+              function(cell, row, col) {
+                if (cell !== null) {
+                  let type = 'String'
+                  let style = ''
+                  let data = parseString(cell, row, col)
+
+                  if (jQuery.isNumeric(data) !== false) {
+                    type = 'Number'
+                  } else {
+                    number = parsePercent(data)
+                    if (number !== false) {
+                      data = number
+                      type = 'Number'
+                      style = ' ss:StyleID="pct1"'
+                    }
+                  }
+
+                  if (type !== 'Number') {
+                    data = data.replace(/\n/g, '<br>')
+                  }
+
+                  trData += '<Cell' + style + '><Data ss:Type="' + type + '">' + data + '</Data></Cell>'
+                }
+              })
+            if (trData.length > 0) {
+              docData += '<Row>' + trData + '</Row>'
+            }
+            rowIndex++
+          })
+
+          docData += '</Table>'
+          docDatas.push(docData)
+
+          if (defaults.consoleLog === true) {
+            console.log(docData)
+          }
+        })
+
+        const CreationDate = new Date().toISOString()
+        var docFile = '<?xml version="1.0" encoding="UTF-8"?><?mso-application progid="Excel.Sheet"?> ' +
+                    '<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" ' +
+                    'xmlns:o="urn:schemas-microsoft-com:office:office" ' +
+                    'xmlns:x="urn:schemas-microsoft-com:office:excel" ' +
+                    'xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet" ' +
+                    'xmlns:html="http://www.w3.org/TR/REC-html40"> ' +
+                    '<DocumentProperties xmlns="urn:schemas-microsoft-com:office:office"> ' +
+                    '<Created>' + CreationDate + '</Created> ' +
+                    '</DocumentProperties> ' +
+                    '<OfficeDocumentSettings xmlns="urn:schemas-microsoft-com:office:office"> ' +
+                    '<AllowPNG/> ' +
+                    '</OfficeDocumentSettings> ' +
+                    '<ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel"> ' +
+                    '<WindowHeight>9000</WindowHeight> ' +
+                    '<WindowWidth>13860</WindowWidth> ' +
+                    '<WindowTopX>0</WindowTopX> ' +
+                    '<WindowTopY>0</WindowTopY> ' +
+                    '<ProtectStructure>False</ProtectStructure> ' +
+                    '<ProtectWindows>False</ProtectWindows> ' +
+                    '</ExcelWorkbook> ' +
+                    '<Styles> ' +
+                    '<Style ss:ID="Default" ss:Name="Default"> ' +
+                    '<Alignment ss:Vertical="Center"/> ' +
+                    '<Borders/> ' +
+                    '<Font/> ' +
+                    '<Interior/> ' +
+                    '<NumberFormat/> ' +
+                    '<Protection/> ' +
+                    '</Style> ' +
+                    '<Style ss:ID="Normal" ss:Name="Normal"/> ' +
+                    '<Style ss:ID="pct1"> ' +
+                    '  <NumberFormat ss:Format="Percent"/> ' +
+                    '</Style> ' +
+                    '</Styles>'
+
+        for (let j = 0; j < docDatas.length; j++) {
+          const ssName = typeof defaults.worksheetName === 'string' ? defaults.worksheetName + ' ' + (j + 1) :
+            typeof defaults.worksheetName[j] !== 'undefined' ? defaults.worksheetName[j] :
+              'Table ' + (j + 1)
+
+          docFile += '<Worksheet ss:Name="' + ssName + '">' +
+                        docDatas[j] +
+                        '<WorksheetOptions/> ' +
+                        '</Worksheet>'
+        }
+
+        docFile += '</Workbook>'
+
+        if (defaults.consoleLog === true) {
+          console.log(docFile)
+        }
+
+        if (defaults.outputMode === 'string') {
+          return docFile
+        }
+
+        if (defaults.outputMode === 'base64') {
+          return base64encode(docFile)
+        }
+
+        try {
+          blob = new Blob([docFile], {
+            type: 'application/xml;charset=utf-8'
+          })
+          saveAs(blob, defaults.fileName + '.xml')
+        } catch (e) {
+          downloadFile(defaults.fileName + '.xml',
+            'data:application/xml;charset=utf-8;base64,',
+            xml)
+        }
+      } else if (defaults.type == 'excel' || defaults.type == 'xls' || defaults.type == 'word' || defaults.type == 'doc') {
+        const MSDocType = (defaults.type == 'excel' || defaults.type == 'xls') ? 'excel' : 'word'
+        const MSDocExt = (MSDocType == 'excel') ? 'xls' : 'doc'
+        const MSDocSchema = 'xmlns:x="urn:schemas-microsoft-com:office:' + MSDocType + '"'
+        var $tables = $(el).filter(function() {
+          return $(this).data('tableexport-display') != 'none' &&
+                        ($(this).is(':visible') ||
+                            $(this).data('tableexport-display') == 'always')
+        })
+        let docData = ''
+
+        $tables.each(function() {
+          const $table = $(this)
+          rowIndex = 0
+          colNames = GetColumnNames(this)
+
+          docData += '<table><thead>'
+          // Header
+          $hrows = $table.find('thead').first().find(defaults.theadSelector)
+          $hrows.each(function() {
+            trData = ''
+            ForEachVisibleCell(this, 'th,td', rowIndex, $hrows.length,
+              function(cell, row, col) {
+                if (cell !== null) {
+                  let thstyle = ''
+                  trData += '<th'
+                  for (const styles in defaults.excelstyles) {
+                    if (defaults.excelstyles.hasOwnProperty(styles)) {
+                      const thcss = $(cell).css(defaults.excelstyles[styles])
+                      if (thcss !== '' && thcss != '0px none rgb(0, 0, 0)' && thcss != 'rgba(0, 0, 0, 0)') {
+                        thstyle += (thstyle === '') ? 'style="' : ';'
+                        thstyle += defaults.excelstyles[styles] + ':' + thcss
+                      }
+                    }
+                  }
+                  if (thstyle !== '' ) {
+                    trData += ' ' + thstyle + '"'
+                  }
+                  if ($(cell).is('[colspan]')) {
+                    trData += ' colspan="' + $(cell).attr('colspan') + '"'
+                  }
+                  if ($(cell).is('[rowspan]')) {
+                    trData += ' rowspan="' + $(cell).attr('rowspan') + '"'
+                  }
+                  trData += '>' + parseString(cell, row, col) + '</th>'
+                }
+              })
+            if (trData.length > 0) {
+              docData += '<tr>' + trData + '</tr>'
+            }
+            rowIndex++
+          })
+
+          docData += '</thead><tbody>'
+          // Row Vs Column, support multiple tbodys
+          $table.find('tbody').each(function() {
+            $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+          })
+          if (defaults.tfootSelector.length) {
+            $rows.push.apply($rows, $table.find('tfoot').find(defaults.tfootSelector))
+          }
+
+          $($rows).each(function() {
+            const $row = $(this)
+            trData = ''
+            ForEachVisibleCell(this, 'td,th', rowIndex, $hrows.length + $rows.length,
+              function(cell, row, col) {
+                if (cell !== null) {
+                  let tdstyle = ''
+                  let tdcss = $(cell).data('tableexport-msonumberformat')
+
+                  if (typeof tdcss == 'undefined' && typeof defaults.onMsoNumberFormat === 'function') {
+                    tdcss = defaults.onMsoNumberFormat(cell, row, col)
+                  }
+
+                  if (typeof tdcss != 'undefined' && tdcss !== '') {
+                    tdstyle = 'style="mso-number-format:\'' + tdcss + '\''
+                  }
+
+                  for (const cssStyle in defaults.excelstyles) {
+                    if (defaults.excelstyles.hasOwnProperty(cssStyle)) {
+                      tdcss = $(cell).css(defaults.excelstyles[cssStyle])
+                      if (tdcss === '') {
+                        tdcss = $row.css(defaults.excelstyles[cssStyle])
+                      }
+
+                      if (tdcss !== '' && tdcss != '0px none rgb(0, 0, 0)' && tdcss != 'rgba(0, 0, 0, 0)') {
+                        tdstyle += (tdstyle === '') ? 'style="' : ';'
+                        tdstyle += defaults.excelstyles[cssStyle] + ':' + tdcss
+                      }
+                    }
+                  }
+                  trData += '<td'
+                  if (tdstyle !== '' ) {
+                    trData += ' ' + tdstyle + '"'
+                  }
+                  if ($(cell).is('[colspan]')) {
+                    trData += ' colspan="' + $(cell).attr('colspan') + '"'
+                  }
+                  if ($(cell).is('[rowspan]')) {
+                    trData += ' rowspan="' + $(cell).attr('rowspan') + '"'
+                  }
+                  trData += '>' + parseString(cell, row, col).replace(/\n/g, '<br>') + '</td>'
+                }
+              })
+            if (trData.length > 0) {
+              docData += '<tr>' + trData + '</tr>'
+            }
+            rowIndex++
+          })
+
+          if (defaults.displayTableName) {
+            docData += '<tr><td></td></tr><tr><td></td></tr><tr><td>' + parseString($('<p>' + defaults.tableName + '</p>')) + '</td></tr>'
+          }
+
+          docData += '</tbody></table>'
+
+          if (defaults.consoleLog === true) {
+            console.log(docData)
+          }
+        })
+
+        var docFile = '<html xmlns:o="urn:schemas-microsoft-com:office:office" ' + MSDocSchema + ' xmlns="http://www.w3.org/TR/REC-html40">'
+        docFile += '<meta http-equiv="content-type" content="application/vnd.ms-' + MSDocType + '; charset=UTF-8">'
+        docFile += '<head>'
+        if (MSDocType === 'excel') {
+          docFile += '<!--[if gte mso 9]>'
+          docFile += '<xml>'
+          docFile += '<x:ExcelWorkbook>'
+          docFile += '<x:ExcelWorksheets>'
+          docFile += '<x:ExcelWorksheet>'
+          docFile += '<x:Name>'
+          docFile += defaults.worksheetName
+          docFile += '</x:Name>'
+          docFile += '<x:WorksheetOptions>'
+          docFile += '<x:DisplayGridlines/>'
+          docFile += '</x:WorksheetOptions>'
+          docFile += '</x:ExcelWorksheet>'
+          docFile += '</x:ExcelWorksheets>'
+          docFile += '</x:ExcelWorkbook>'
+          docFile += '</xml>'
+          docFile += '<![endif]-->'
+        }
+        docFile += '<style>br {mso-data-placement:same-cell;}</style>'
+        docFile += '</head>'
+        docFile += '<body>'
+        docFile += docData
+        docFile += '</body>'
+        docFile += '</html>'
+
+        if (defaults.consoleLog === true) {
+          console.log(docFile)
+        }
+
+        if (defaults.outputMode === 'string') {
+          return docFile
+        }
+
+        if (defaults.outputMode === 'base64') {
+          return base64encode(docFile)
+        }
+
+        try {
+          blob = new Blob([docFile], {
+            type: 'application/vnd.ms-' + defaults.type
+          })
+          saveAs(blob, defaults.fileName + '.' + MSDocExt)
+        } catch (e) {
+          downloadFile(defaults.fileName + '.' + MSDocExt,
+            'data:application/vnd.ms-' + MSDocType + ';base64,',
+            docFile)
+        }
+      } else if (defaults.type == 'xlsx') {
+        const data = []
+        const ranges = []
+        rowIndex = 0
+
+        $rows = $(el).find('thead').first()
+          .find(defaults.theadSelector)
+        $(el).find('tbody').each(function() {
+          $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+        })
+        if (defaults.tfootSelector.length) {
+          $rows.push.apply($rows, $(el).find('tfoot').find(defaults.tfootSelector))
+        }
+
+        $($rows).each(function() {
+          const cols = []
+          ForEachVisibleCell(this, 'th,td', rowIndex, $rows.length,
+            function(cell, row, col) {
+              if (typeof cell !== 'undefined' && cell !== null) {
+                let colspan = parseInt(cell.getAttribute('colspan'))
+                let rowspan = parseInt(cell.getAttribute('rowspan'))
+
+                let cellValue = parseString(cell, row, col)
+
+                if (cellValue !== '' && cellValue == +cellValue) cellValue = +cellValue
+
+                // Skip ranges
+                ranges.forEach(function(range) {
+                  if (rowIndex >= range.s.r && rowIndex <= range.e.r && cols.length >= range.s.c && cols.length <= range.e.c) {
+                    for (let i = 0; i <= range.e.c - range.s.c; ++i) cols.push(null)
+                  }
+                })
+
+                // Handle Row Span
+                if (rowspan || colspan) {
+                  rowspan = rowspan || 1
+                  colspan = colspan || 1
+                  ranges.push({
+                    s: {
+                      r: rowIndex,
+                      c: cols.length
+                    },
+                    e: {
+                      r: rowIndex + rowspan - 1,
+                      c: cols.length + colspan - 1
+                    }
+                  })
+                }
+
+                // Handle Value
+                cols.push(cellValue !== '' ? cellValue : null)
+
+                // Handle Colspan
+                if (colspan) for (let k = 0; k < colspan - 1; ++k) cols.push(null)
+              }
+            })
+          data.push(cols)
+          rowIndex++
+        })
+
+        const wb = new jx_Workbook()
+        const ws = jx_createSheet(data)
+
+        // add ranges to worksheet
+        ws['!merges'] = ranges
+
+        // add worksheet to workbook
+        wb.SheetNames.push(defaults.worksheetName)
+        wb.Sheets[defaults.worksheetName] = ws
+
+        const wbout = XLSX.write(wb, {
+          bookType: defaults.type,
+          bookSST: false,
+          type: 'binary'
+        })
+
+        try {
+          blob = new Blob([jx_s2ab(wbout)], {
+            type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8'
+          })
+          saveAs(blob, defaults.fileName + '.' + defaults.type)
+        } catch (e) {
+          downloadFile(defaults.fileName + '.' + defaults.type,
+            'data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8,',
+            blob)
+        }
+      } else if (defaults.type == 'png') {
+        // html2canvas($(el)[0], {
+        //  onrendered: function (canvas) {
+        html2canvas($(el)[0]).then(
+          function(canvas) {
+            const image = canvas.toDataURL()
+            const byteString = atob(image.substring(22)) // remove data stuff
+            const buffer = new ArrayBuffer(byteString.length)
+            const intArray = new Uint8Array(buffer)
+
+            for (let i = 0; i < byteString.length; i++) {
+              intArray[i] = byteString.charCodeAt(i)
+            }
+
+            if (defaults.consoleLog === true) {
+              console.log(byteString)
+            }
+
+            if (defaults.outputMode === 'string') {
+              return byteString
+            }
+
+            if (defaults.outputMode === 'base64') {
+              return base64encode(image)
+            }
+
+            if (defaults.outputMode === 'window') {
+              window.open(image)
+              return
+            }
+
+            try {
+              blob = new Blob([buffer], {
+                type: 'image/png'
+              })
+              saveAs(blob, defaults.fileName + '.png')
+            } catch (e) {
+              downloadFile(defaults.fileName + '.png', 'data:image/png,', blob)
+            }
+            // }
+          })
+      } else if (defaults.type == 'pdf') {
+        if (defaults.pdfmake.enabled === true) {
+          // pdf output using pdfmake
+          // https://github.com/bpampuch/pdfmake
+
+          const widths = []
+          const body = []
+          rowIndex = 0
+
+          const CollectPdfmakeData = function($rows, colselector, length) {
+            let rlength = 0
+
+            $($rows).each(function() {
+              const r = []
+
+              ForEachVisibleCell(this, colselector, rowIndex, length,
+                function(cell, row, col) {
+                  if (typeof cell !== 'undefined' && cell !== null) {
+                    let colspan = parseInt(cell.getAttribute('colspan'))
+                    let rowspan = parseInt(cell.getAttribute('rowspan'))
+
+                    const cellValue = parseString(cell, row, col) || ' '
+
+                    if (colspan > 1 || rowspan > 1) {
+                      colspan = colspan || 1
+                      rowspan = rowspan || 1
+                      r.push({
+                        colSpan: colspan,
+                        rowSpan: rowspan,
+                        text: cellValue
+                      })
+                    } else {
+                      r.push(cellValue)
+                    }
+                  } else {
+                    r.push(' ')
+                  }
+                })
+
+              if (r.length) {
+                body.push(r)
+              }
+
+              if ( rlength < r.length ) {
+                rlength = r.length
+              }
+
+              rowIndex++
+            })
+
+            return rlength
+          }
+
+          $hrows = $(this).find('thead').first()
+            .find(defaults.theadSelector)
+
+          const colcount = CollectPdfmakeData($hrows, 'th,td', $hrows.length)
+
+          for (let i = widths.length; i < colcount; i++) {
+            widths.push('*')
+          }
+
+          $(this).find('tbody').each(function() {
+            $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+          })
+          if (defaults.tfootSelector.length) {
+            $rows.push.apply($rows, $(this).find('tfoot').find(defaults.tfootSelector))
+          }
+
+          CollectPdfmakeData($rows, 'th,td', $hrows.length + $rows.length)
+
+          const docDefinition = {
+            content: [{
+              table: {
+                headerRows: $hrows.length,
+                widths: widths,
+                body: body
+              }
+            }]
+          }
+
+          $.extend(true, docDefinition, defaults.pdfmake.docDefinition)
+
+          pdfMake.fonts = {
+            Roboto: {
+              normal: 'Roboto-Regular.ttf',
+              bold: 'Roboto-Medium.ttf',
+              italics: 'Roboto-Italic.ttf',
+              bolditalics: 'Roboto-MediumItalic.ttf'
+            }
+          }
+
+          $.extend(true, pdfMake.fonts, defaults.pdfmake.fonts)
+
+          pdfMake.createPdf(docDefinition).getBuffer(function(buffer) {
+            try {
+              const blob = new Blob([buffer], {
+                type: 'application/pdf'
+              })
+              saveAs(blob, defaults.fileName + '.pdf')
+            } catch (e) {
+              downloadFile(defaults.fileName + '.pdf',
+                'data:application/pdf;base64,',
+                buffer)
+            }
+          })
+        } else if (defaults.jspdf.autotable === false) {
+          // pdf output using jsPDF's core html support
+
+          const addHtmlOptions = {
+            dim: {
+              w: getPropertyUnitValue($(el).first().get(0), 'width', 'mm'),
+              h: getPropertyUnitValue($(el).first().get(0), 'height', 'mm')
+            },
+            pagesplit: false
+          }
+
+          const doc = new jsPDF(defaults.jspdf.orientation, defaults.jspdf.unit, defaults.jspdf.format)
+          doc.addHTML($(el).first(),
+            defaults.jspdf.margins.left,
+            defaults.jspdf.margins.top,
+            addHtmlOptions,
+            function() {
+              jsPdfOutput(doc, false)
+            })
+          // delete doc;
+        } else {
+          // pdf output using jsPDF AutoTable plugin
+          // https://github.com/simonbengtsson/jsPDF-AutoTable
+
+          const teOptions = defaults.jspdf.autotable.tableExport
+
+          // When setting jspdf.format to 'bestfit' tableExport tries to choose
+          // the minimum required paper format and orientation in which the table
+          // (or tables in multitable mode) completely fits without column adjustment
+          if (typeof defaults.jspdf.format === 'string' && defaults.jspdf.format.toLowerCase() === 'bestfit') {
+            const pageFormats = {
+              'a0': [2383.94, 3370.39],
+              'a1': [1683.78, 2383.94],
+              'a2': [1190.55, 1683.78],
+              'a3': [841.89, 1190.55],
+              'a4': [595.28, 841.89]
+            }
+            let rk = ''; let ro = ''
+            let mw = 0
+
+            $(el).filter(':visible').each(function() {
+              if ($(this).css('display') != 'none') {
+                const w = getPropertyUnitValue($(this).get(0), 'width', 'pt')
+
+                if (w > mw) {
+                  if (w > pageFormats.a0[0]) {
+                    rk = 'a0'
+                    ro = 'l'
+                  }
+                  for (const key in pageFormats) {
+                    if (pageFormats.hasOwnProperty(key)) {
+                      if (pageFormats[key][1] > w) {
+                        rk = key
+                        ro = 'l'
+                        if (pageFormats[key][0] > w) {
+                          ro = 'p'
+                        }
+                      }
+                    }
+                  }
+                  mw = w
+                }
+              }
+            })
+            defaults.jspdf.format = (rk === '' ? 'a4' : rk)
+            defaults.jspdf.orientation = (ro === '' ? 'w' : ro)
+          }
+
+          // The jsPDF doc object is stored in defaults.jspdf.autotable.tableExport,
+          // thus it can be accessed from any callback function
+          teOptions.doc = new jsPDF(defaults.jspdf.orientation,
+            defaults.jspdf.unit,
+            defaults.jspdf.format)
+
+          if (teOptions.outputImages === true) {
+            teOptions.images = {}
+          }
+
+          if (typeof teOptions.images != 'undefined') {
+            $(el).filter(function() {
+              return $(this).data('tableexport-display') != 'none' &&
+                                ($(this).is(':visible') ||
+                                    $(this).data('tableexport-display') == 'always')
+            }).each(function() {
+              let rowCount = 0
+
+              $hrows = $(this).find('thead').find(defaults.theadSelector)
+              $(this).find('tbody').each(function() {
+                $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+              })
+              if (defaults.tfootSelector.length) {
+                $rows.push.apply($rows, $(this).find('tfoot').find(defaults.tfootSelector))
+              }
+
+              $($rows).each(function() {
+                ForEachVisibleCell(this, 'td,th', $hrows.length + rowCount, $hrows.length + $rows.length,
+                  function(cell, row, col) {
+                    if (typeof cell !== 'undefined' && cell !== null) {
+                      const kids = $(cell).children()
+                      if (typeof kids != 'undefined' && kids.length > 0) {
+                        collectImages(cell, kids, teOptions)
+                      }
+                    }
+                  })
+                rowCount++
+              })
+            })
+
+            $hrows = []
+            $rows = []
+          }
+
+          loadImages( teOptions, function(imageCount) {
+            $(el).filter(function() {
+              return $(this).data('tableexport-display') != 'none' &&
+                                ($(this).is(':visible') ||
+                                    $(this).data('tableexport-display') == 'always')
+            }).each(function() {
+              let colKey
+              let rowIndex = 0
+
+              colNames = GetColumnNames(this)
+
+              teOptions.columns = []
+              teOptions.rows = []
+              teOptions.rowoptions = {}
+
+              // onTable: optional callback function for every matching table that can be used
+              // to modify the tableExport options or to skip the output of a particular table
+              // if the table selector targets multiple tables
+              if (typeof teOptions.onTable === 'function') {
+                if (teOptions.onTable($(this), defaults) === false) {
+                  return true
+                }
+              } // continue to next iteration step (table)
+
+              // each table works with an own copy of AutoTable options
+              defaults.jspdf.autotable.tableExport = null // avoid deep recursion error
+              const atOptions = $.extend(true, {}, defaults.jspdf.autotable)
+              defaults.jspdf.autotable.tableExport = teOptions
+
+              atOptions.margin = {}
+              $.extend(true, atOptions.margin, defaults.jspdf.margins)
+              atOptions.tableExport = teOptions
+
+              // Fix jsPDF Autotable's row height calculation
+              if (typeof atOptions.beforePageContent !== 'function') {
+                atOptions.beforePageContent = function(data) {
+                  if (data.pageCount == 1) {
+                    const all = data.table.rows.concat(data.table.headerRow)
+                    all.forEach(function(row) {
+                      if ( row.height > 0 ) {
+                        row.height += (2 - FONT_ROW_RATIO) / 2 * row.styles.fontSize
+                        data.table.height += (2 - FONT_ROW_RATIO) / 2 * row.styles.fontSize
+                      }
+                    })
+                  }
+                }
+              }
+
+              if (typeof atOptions.createdHeaderCell !== 'function') {
+                // apply some original css styles to pdf header cells
+                atOptions.createdHeaderCell = function(cell, data) {
+                  // jsPDF AutoTable plugin v2.0.14 fix: each cell needs its own styles object
+                  cell.styles = $.extend({}, data.row.styles)
+
+                  if (typeof teOptions.columns [data.column.dataKey] != 'undefined') {
+                    const col = teOptions.columns [data.column.dataKey]
+
+                    if (typeof col.rect != 'undefined') {
+                      let rh
+
+                      cell.contentWidth = col.rect.width
+
+                      if (typeof teOptions.heightRatio == 'undefined' || teOptions.heightRatio === 0) {
+                        if (data.row.raw [data.column.dataKey].rowspan) {
+                          rh = data.row.raw [data.column.dataKey].rect.height / data.row.raw [data.column.dataKey].rowspan
+                        } else {
+                          rh = data.row.raw [data.column.dataKey].rect.height
+                        }
+
+                        teOptions.heightRatio = cell.styles.rowHeight / rh
+                      }
+
+                      rh = data.row.raw [data.column.dataKey].rect.height * teOptions.heightRatio
+                      if (rh > cell.styles.rowHeight) {
+                        cell.styles.rowHeight = rh
+                      }
+                    }
+
+                    if (typeof col.style != 'undefined' && col.style.hidden !== true) {
+                      cell.styles.halign = col.style.align
+                      if (atOptions.styles.fillColor === 'inherit') {
+                        cell.styles.fillColor = col.style.bcolor
+                      }
+                      if (atOptions.styles.textColor === 'inherit') {
+                        cell.styles.textColor = col.style.color
+                      }
+                      if (atOptions.styles.fontStyle === 'inherit') {
+                        cell.styles.fontStyle = col.style.fstyle
+                      }
+                    }
+                  }
+                }
+              }
+
+              if (typeof atOptions.createdCell !== 'function') {
+                // apply some original css styles to pdf table cells
+                atOptions.createdCell = function(cell, data) {
+                  const rowopt = teOptions.rowoptions [data.row.index + ':' + data.column.dataKey]
+
+                  if (typeof rowopt != 'undefined' &&
+                                        typeof rowopt.style != 'undefined' &&
+                                        rowopt.style.hidden !== true) {
+                    cell.styles.halign = rowopt.style.align
+                    if (atOptions.styles.fillColor === 'inherit') {
+                      cell.styles.fillColor = rowopt.style.bcolor
+                    }
+                    if (atOptions.styles.textColor === 'inherit') {
+                      cell.styles.textColor = rowopt.style.color
+                    }
+                    if (atOptions.styles.fontStyle === 'inherit') {
+                      cell.styles.fontStyle = rowopt.style.fstyle
+                    }
+                  }
+                }
+              }
+
+              if (typeof atOptions.drawHeaderCell !== 'function') {
+                atOptions.drawHeaderCell = function(cell, data) {
+                  const colopt = teOptions.columns [data.column.dataKey]
+
+                  if ((colopt.style.hasOwnProperty('hidden') !== true || colopt.style.hidden !== true) &&
+                                        colopt.rowIndex >= 0 ) {
+                    return prepareAutoTableText(cell, data, colopt)
+                  } else {
+                    return false
+                  } // cell is hidden
+                }
+              }
+
+              if (typeof atOptions.drawCell !== 'function') {
+                atOptions.drawCell = function(cell, data) {
+                  const rowopt = teOptions.rowoptions [data.row.index + ':' + data.column.dataKey]
+                  if ( prepareAutoTableText(cell, data, rowopt) ) {
+                    teOptions.doc.rect(cell.x, cell.y, cell.width, cell.height, cell.styles.fillStyle)
+
+                    if (typeof rowopt != 'undefined' && typeof rowopt.kids != 'undefined' && rowopt.kids.length > 0) {
+                      const dh = cell.height / rowopt.rect.height
+                      if (dh > teOptions.dh || typeof teOptions.dh == 'undefined') {
+                        teOptions.dh = dh
+                      }
+                      teOptions.dw = cell.width / rowopt.rect.width
+
+                      const y = cell.textPos.y
+                      drawAutotableElements(cell, rowopt.kids, teOptions)
+                      cell.textPos.y = y
+                      drawAutotableText(cell, rowopt.kids, teOptions)
+                    } else {
+                      drawAutotableText(cell, {}, teOptions)
+                    }
+                  }
+                  return false
+                }
+              }
+
+              // collect header and data rows
+              teOptions.headerrows = []
+              $hrows = $(this).find('thead').find(defaults.theadSelector)
+              $hrows.each(function() {
+                colKey = 0
+
+                teOptions.headerrows[rowIndex] = []
+
+                ForEachVisibleCell(this, 'th,td', rowIndex, $hrows.length,
+                  function(cell, row, col) {
+                    const obj = getCellStyles(cell)
+                    obj.title = parseString(cell, row, col)
+                    obj.key = colKey++
+                    obj.rowIndex = rowIndex
+                    teOptions.headerrows[rowIndex].push(obj)
+                  })
+                rowIndex++
+              })
+
+              if (rowIndex > 0) {
+                // iterate through last row
+                let lastrow = rowIndex - 1
+                while (lastrow >= 0) {
+                  $.each(teOptions.headerrows[lastrow], function() {
+                    let obj = this
+
+                    if (lastrow > 0 && this.rect === null) {
+                      obj = teOptions.headerrows[lastrow - 1][this.key]
+                    }
+
+                    if (obj !== null && obj.rowIndex >= 0 &&
+                                            (obj.style.hasOwnProperty('hidden') !== true || obj.style.hidden !== true)) {
+                      teOptions.columns.push(obj)
+                    }
+                  })
+
+                  lastrow = (teOptions.columns.length > 0) ? -1 : lastrow - 1
+                }
+              }
+
+              let rowCount = 0
+              $rows = []
+              $(this).find('tbody').each(function() {
+                $rows.push.apply($rows, $(this).find(defaults.tbodySelector))
+              })
+              if (defaults.tfootSelector.length) {
+                $rows.push.apply($rows, $(this).find('tfoot').find(defaults.tfootSelector))
+              }
+              $($rows).each(function() {
+                const rowData = []
+                colKey = 0
+
+                ForEachVisibleCell(this, 'td,th', rowIndex, $hrows.length + $rows.length,
+                  function(cell, row, col) {
+                    if (typeof teOptions.columns[colKey] === 'undefined') {
+                      // jsPDF-Autotable needs columns. Thus define hidden ones for tables without thead
+                      var obj = {
+                        title: '',
+                        key: colKey,
+                        style: {
+                          hidden: true
+                        }
+                      }
+                      teOptions.columns.push(obj)
+                    }
+                    if (typeof cell !== 'undefined' && cell !== null) {
+                      var obj = getCellStyles(cell)
+                      obj.kids = $(cell).children()
+                      teOptions.rowoptions [rowCount + ':' + colKey++] = obj
+                    } else {
+                      var obj = $.extend(true, {}, teOptions.rowoptions [rowCount + ':' + (colKey - 1)])
+                      obj.colspan = -1
+                      teOptions.rowoptions [rowCount + ':' + colKey++] = obj
+                    }
+
+                    rowData.push(parseString(cell, row, col))
+                  })
+                if (rowData.length) {
+                  teOptions.rows.push(rowData)
+                  rowCount++
+                }
+                rowIndex++
+              })
+
+              // onBeforeAutotable: optional callback function before calling
+              // jsPDF AutoTable that can be used to modify the AutoTable options
+              if (typeof teOptions.onBeforeAutotable === 'function') {
+                teOptions.onBeforeAutotable($(this), teOptions.columns, teOptions.rows, atOptions)
+              }
+
+              teOptions.doc.autoTable(teOptions.columns, teOptions.rows, atOptions)
+
+              // onAfterAutotable: optional callback function after returning
+              // from jsPDF AutoTable that can be used to modify the AutoTable options
+              if (typeof teOptions.onAfterAutotable === 'function') {
+                teOptions.onAfterAutotable($(this), atOptions)
+              }
+
+              // set the start position for the next table (in case there is one)
+              defaults.jspdf.autotable.startY = teOptions.doc.autoTableEndPosY() + atOptions.margin.top
+            })
+
+            jsPdfOutput(teOptions.doc, (typeof teOptions.images != 'undefined' && jQuery.isEmptyObject(teOptions.images) === false))
+
+            if (typeof teOptions.headerrows != 'undefined') {
+              teOptions.headerrows.length = 0
+            }
+            if (typeof teOptions.columns != 'undefined') {
+              teOptions.columns.length = 0
+            }
+            if (typeof teOptions.rows != 'undefined') {
+              teOptions.rows.length = 0
+            }
+            delete teOptions.doc
+            teOptions.doc = null
+          })
+        }
+      }
+
+      function FindColObject(objects, colIndex, rowIndex) {
+        let result = null
+        $.each(objects, function() {
+          if (this.rowIndex == rowIndex && this.key == colIndex) {
+            result = this
+            return false
+          }
+        })
+        return result
+      }
+
+      function GetColumnNames(table) {
+        const result = []
+        $(table).find('thead').first()
+          .find('th')
+          .each(function(index, el) {
+            if ($(el).attr('data-field') !== undefined) {
+              result[index] = $(el).attr('data-field')
+            } else {
+              result[index] = index.toString()
+            }
+          })
+        return result
+      }
+
+      function isColumnIgnored(rowLength, colIndex) {
+        let result = false
+        if (defaults.ignoreColumn.length > 0) {
+          if (typeof defaults.ignoreColumn[0] == 'string') {
+            if (colNames.length > colIndex && typeof colNames[colIndex] != 'undefined') {
+              if ($.inArray(colNames[colIndex], defaults.ignoreColumn) != -1) {
+                result = true
+              }
+            }
+          } else if (typeof defaults.ignoreColumn[0] == 'number') {
+            if ($.inArray(colIndex, defaults.ignoreColumn) != -1 ||
+                            $.inArray(colIndex - rowLength, defaults.ignoreColumn) != -1) {
+              result = true
+            }
+          }
+        }
+        return result
+      }
+
+      function ForEachVisibleCell(tableRow, selector, rowIndex, rowCount, cellcallback) {
+        if ($.inArray(rowIndex, defaults.ignoreRow) == -1 &&
+                    $.inArray(rowIndex - rowCount, defaults.ignoreRow) == -1) {
+          const $row = $(tableRow).filter(function() {
+            return $(this).data('tableexport-display') != 'none' &&
+                            ($(this).is(':visible') ||
+                                $(this).data('tableexport-display') == 'always' ||
+                                $(this).closest('table').data('tableexport-display') == 'always')
+          }).find(selector)
+
+          let rowColspan = 0
+
+          $row.each(function(colIndex) {
+            if ($(this).data('tableexport-display') == 'always' ||
+                            ($(this).css('display') != 'none' &&
+                                $(this).css('visibility') != 'hidden' &&
+                                $(this).data('tableexport-display') != 'none')) {
+              if (typeof (cellcallback) === 'function') {
+                let c; let Colspan = 1
+                let r; let Rowspan = 1
+                let rowLength = $row.length
+
+                // handle rowspans from previous rows
+                if (typeof rowspans[rowIndex] != 'undefined' && rowspans[rowIndex].length > 0) {
+                  let colCount = colIndex
+                  for (c = 0; c <= colCount; c++) {
+                    if (typeof rowspans[rowIndex][c] != 'undefined') {
+                      cellcallback(null, rowIndex, c)
+                      delete rowspans[rowIndex][c]
+                      colCount++
+                    }
+                  }
+                  colIndex += rowspans[rowIndex].length
+                  rowLength += rowspans[rowIndex].length
+                }
+
+                if ($(this).is('[colspan]')) {
+                  Colspan = parseInt($(this).attr('colspan')) || 1
+
+                  rowColspan += Colspan > 0 ? Colspan - 1 : 0
+                }
+
+                if ($(this).is('[rowspan]')) {
+                  Rowspan = parseInt($(this).attr('rowspan')) || 1
+                }
+
+                if (isColumnIgnored(rowLength, colIndex + rowColspan) === false) {
+                  // output content of current cell
+                  cellcallback(this, rowIndex, colIndex)
+
+                  // handle colspan of current cell
+                  for (c = 1; c < Colspan; c++) {
+                    cellcallback(null, rowIndex, colIndex + c)
+                  }
+                }
+
+                // store rowspan for following rows
+                if (Rowspan > 1) {
+                  for (r = 1; r < Rowspan; r++) {
+                    if (typeof rowspans[rowIndex + r] == 'undefined') {
+                      rowspans[rowIndex + r] = []
+                    }
+
+                    rowspans[rowIndex + r][colIndex + rowColspan] = ''
+
+                    for (c = 1; c < Colspan; c++) {
+                      rowspans[rowIndex + r][colIndex + rowColspan - c] = ''
+                    }
+                  }
+                }
+              }
+            }
+          })
+          // handle rowspans from previous rows
+          if (typeof rowspans[rowIndex] != 'undefined' && rowspans[rowIndex].length > 0) {
+            for (let c = 0; c <= rowspans[rowIndex].length; c++) {
+              if (typeof rowspans[rowIndex][c] != 'undefined') {
+                cellcallback(null, rowIndex, c)
+                delete rowspans[rowIndex][c]
+              }
+            }
+          }
+        }
+      }
+
+      function jsPdfOutput(doc, hasimages) {
+        if (defaults.consoleLog === true) {
+          console.log(doc.output())
+        }
+
+        if (defaults.outputMode === 'string') {
+          return doc.output()
+        }
+
+        if (defaults.outputMode === 'base64') {
+          return base64encode(doc.output())
+        }
+
+        if (defaults.outputMode === 'window') {
+          window.open(URL.createObjectURL(doc.output('blob')))
+          return
+        }
+
+        try {
+          var blob = doc.output('blob')
+          saveAs(blob, defaults.fileName + '.pdf')
+        } catch (e) {
+          downloadFile(defaults.fileName + '.pdf',
+            'data:application/pdf' + (hasimages ? '' : ';base64') + ',',
+            hasimages ? blob : doc.output())
+        }
+      }
+
+      function prepareAutoTableText(cell, data, cellopt) {
+        let cs = 0
+        if ( typeof cellopt != 'undefined' ) {
+          cs = cellopt.colspan
+        }
+
+        if ( cs >= 0 ) {
+          // colspan handling
+          let cellWidth = cell.width
+          let textPosX = cell.textPos.x
+          const i = data.table.columns.indexOf(data.column)
+
+          for (let c = 1; c < cs; c++) {
+            const column = data.table.columns[i + c]
+            cellWidth += column.width
+          }
+
+          if ( cs > 1 ) {
+            if ( cell.styles.halign === 'right' ) {
+              textPosX = cell.textPos.x + cellWidth - cell.width
+            } else if ( cell.styles.halign === 'center' ) {
+              textPosX = cell.textPos.x + (cellWidth - cell.width) / 2
+            }
+          }
+
+          cell.width = cellWidth
+          cell.textPos.x = textPosX
+
+          if ( typeof cellopt != 'undefined' && cellopt.rowspan > 1 ) {
+            cell.height = cell.height * cellopt.rowspan
+          }
+
+          // fix jsPDF's calculation of text position
+          if ( cell.styles.valign === 'middle' || cell.styles.valign === 'bottom' ) {
+            const splittedText = typeof cell.text === 'string' ? cell.text.split(/\r\n|\r|\n/g) : cell.text
+            const lineCount = splittedText.length || 1
+            if (lineCount > 2) {
+              cell.textPos.y -= ((2 - FONT_ROW_RATIO) / 2 * data.row.styles.fontSize) * (lineCount - 2) / 3
+            }
+          }
+          return true
+        } else {
+          return false
+        } // cell is hidden (colspan = -1), don't draw it
+      }
+
+      function collectImages(cell, elements, teOptions) {
+        if (typeof teOptions.images != 'undefined') {
+          elements.each(function() {
+            const kids = $(this).children()
+
+            if ( $(this).is('img') ) {
+              const hash = strHashCode(this.src)
+
+              teOptions.images[hash] = {
+                url: this.src,
+                src: this.src
+              }
+            }
+
+            if (typeof kids != 'undefined' && kids.length > 0) {
+              collectImages(cell, kids, teOptions)
+            }
+          })
+        }
+      }
+
+      function loadImages(teOptions, callback) {
+        let i
+        let imageCount = 0
+        let x = 0
+
+        function done() {
+          callback(imageCount)
+        }
+        function loadImage(image) {
+          if (!image.url) {
+            return
+          }
+          const img = new Image()
+          imageCount = ++x
+          img.crossOrigin = 'Anonymous'
+          img.onerror = img.onload = function() {
+            if (img.complete) {
+              if (img.src.indexOf('data:image/') === 0) {
+                img.width = image.width || img.width || 0
+                img.height = image.height || img.height || 0
+              }
+
+              if (img.width + img.height) {
+                const canvas = document.createElement('canvas')
+                const ctx = canvas.getContext('2d')
+
+                canvas.width = img.width
+                canvas.height = img.height
+                ctx.drawImage( img, 0, 0 )
+
+                image.src = canvas.toDataURL('image/jpeg')
+              }
+            }
+            if (!--x) {
+              done()
+            }
+          }
+          img.src = image.url
+        }
+
+        if (typeof teOptions.images != 'undefined') {
+          for (i in teOptions.images) {
+            if (teOptions.images.hasOwnProperty(i)) {
+              loadImage(teOptions.images[i])
+            }
+          }
+        }
+
+        return x || done()
+      }
+
+      function drawAutotableElements(cell, elements, teOptions) {
+        elements.each(function() {
+          const kids = $(this).children()
+
+          if ( $(this).is('div') ) {
+            const bcolor = rgb2array(getStyle(this, 'background-color'), [255, 255, 255])
+            const lcolor = rgb2array(getStyle(this, 'border-top-color'), [0, 0, 0])
+            const lwidth = getPropertyUnitValue(this, 'border-top-width', defaults.jspdf.unit)
+
+            const r = this.getBoundingClientRect()
+            const ux = this.offsetLeft * teOptions.dw
+            var uy = this.offsetTop * teOptions.dh
+            const uw = r.width * teOptions.dw
+            const uh = r.height * teOptions.dh
+
+            teOptions.doc.setDrawColor.apply(undefined, lcolor)
+            teOptions.doc.setFillColor.apply(undefined, bcolor)
+            teOptions.doc.setLineWidth(lwidth)
+            teOptions.doc.rect(cell.x + ux, cell.y + uy, uw, uh, lwidth ? 'FD' : 'F')
+          } else if ( $(this).is('img') ) {
+            if (typeof teOptions.images != 'undefined') {
+              const hash = strHashCode(this.src)
+              const image = teOptions.images[hash]
+
+              if (typeof image != 'undefined') {
+                const arCell = cell.width / cell.height
+                const arImg = this.width / this.height
+                let imgWidth = cell.width
+                let imgHeight = cell.height
+                const px2pt = 0.264583 * 72 / 25.4
+                var uy = 0
+
+                if (arImg <= arCell) {
+                  imgHeight = Math.min(cell.height, this.height)
+                  imgWidth = this.width * imgHeight / this.height
+                } else if (arImg > arCell) {
+                  imgWidth = Math.min(cell.width, this.width)
+                  imgHeight = this.height * imgWidth / this.width
+                }
+
+                imgWidth *= px2pt
+                imgHeight *= px2pt
+
+                if (imgHeight < cell.height) {
+                  uy = (cell.height - imgHeight) / 2
+                }
+
+                try {
+                  teOptions.doc.addImage(image.src, cell.textPos.x, cell.y + uy, imgWidth, imgHeight)
+                } catch (e) {
+                  // TODO: IE -> convert png to jpeg
+                }
+                cell.textPos.x += imgWidth
+              }
+            }
+          }
+
+          if (typeof kids != 'undefined' && kids.length > 0) {
+            drawAutotableElements(cell, kids, teOptions)
+          }
+        })
+      }
+
+      function drawAutotableText(cell, texttags, teOptions) {
+        if (typeof teOptions.onAutotableText === 'function') {
+          teOptions.onAutotableText(teOptions.doc, cell, texttags)
+        } else {
+          let x = cell.textPos.x
+          let y = cell.textPos.y
+          const style = {
+            halign: cell.styles.halign,
+            valign: cell.styles.valign
+          }
+
+          if (texttags.length) {
+            let tag = texttags[0]
+            while (tag.previousSibling) {
+              tag = tag.previousSibling
+            }
+
+            let b = false; let i = false
+
+            while (tag) {
+              let txt = tag.innerText || tag.textContent || ''
+
+              txt = ((txt.length && txt[0] == ' ') ? ' ' : '') +
+                                $.trim(txt) +
+                                ((txt.length > 1 && txt[txt.length - 1] == ' ') ? ' ' : '')
+
+              if ($(tag).is('br')) {
+                x = cell.textPos.x
+                y += teOptions.doc.internal.getFontSize()
+              }
+
+              if ($(tag).is('b')) {
+                b = true
+              } else if ($(tag).is('i')) {
+                i = true
+              }
+
+              if (b || i) {
+                teOptions.doc.setFontType((b && i) ? 'bolditalic' : b ? 'bold' : 'italic')
+              }
+
+              let w = teOptions.doc.getStringUnitWidth(txt) * teOptions.doc.internal.getFontSize()
+
+              if (w) {
+                if (cell.styles.overflow === 'linebreak' &&
+                                    x > cell.textPos.x && (x + w) > (cell.textPos.x + cell.width)) {
+                  const chars = '.,!%*;:=-'
+                  if (chars.indexOf(txt.charAt(0)) >= 0) {
+                    const s = txt.charAt(0)
+                    w = teOptions.doc.getStringUnitWidth(s) * teOptions.doc.internal.getFontSize()
+                    if ((x + w) <= (cell.textPos.x + cell.width)) {
+                      teOptions.doc.autoTableText(s, x, y, style)
+                      txt = txt.substring(1, txt.length)
+                    }
+                    w = teOptions.doc.getStringUnitWidth(txt) * teOptions.doc.internal.getFontSize()
+                  }
+                  x = cell.textPos.x
+                  y += teOptions.doc.internal.getFontSize()
+                }
+
+                while (txt.length && (x + w) > (cell.textPos.x + cell.width)) {
+                  txt = txt.substring(0, txt.length - 1)
+                  w = teOptions.doc.getStringUnitWidth(txt) * teOptions.doc.internal.getFontSize()
+                }
+
+                teOptions.doc.autoTableText(txt, x, y, style)
+                x += w
+              }
+
+              if (b || i) {
+                if ($(tag).is('b')) {
+                  b = false
+                } else if ($(tag).is('i')) {
+                  i = false
+                }
+
+                teOptions.doc.setFontType((!b && !i) ? 'normal' : b ? 'bold' : 'italic')
+              }
+
+              tag = tag.nextSibling
+            }
+            cell.textPos.x = x
+            cell.textPos.y = y
+          } else {
+            teOptions.doc.autoTableText(cell.text, cell.textPos.x, cell.textPos.y, style)
+          }
+        }
+      }
+
+      function escapeRegExp(string) {
+        return string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1')
+      }
+
+      function replaceAll(string, find, replace) {
+        return string.replace(new RegExp(escapeRegExp(find), 'g'), replace)
+      }
+
+      function parseNumber(value) {
+        value = value || '0'
+        value = replaceAll(value, defaults.numbers.html.thousandsSeparator, '')
+        value = replaceAll(value, defaults.numbers.html.decimalMark, '.')
+
+        return typeof value === 'number' || jQuery.isNumeric(value) !== false ? value : false
+      }
+
+      function parsePercent(value) {
+        if (value.indexOf('%') > -1) {
+          value = parseNumber(value.replace(/%/g, ''))
+          if (value !== false) {
+            value = value / 100
+          }
+        } else {
+          value = false
+        }
+        return value
+      }
+
+      function parseString(cell, rowIndex, colIndex) {
+        let result = ''
+
+        if (cell !== null) {
+          const $cell = $(cell)
+          let htmlData
+
+          if ($cell[0].hasAttribute('data-tableexport-value')) {
+            htmlData = $cell.data('tableexport-value')
+          } else {
+            htmlData = $cell.html()
+
+            if (typeof defaults.onCellHtmlData === 'function') {
+              htmlData = defaults.onCellHtmlData($cell, rowIndex, colIndex, htmlData)
+            } else if (htmlData != '') {
+              const html = $.parseHTML( htmlData )
+              let inputidx = 0
+              let selectidx = 0
+
+              htmlData = ''
+              $.each( html, function() {
+                if ( $(this).is('input') ) {
+                  htmlData += $cell.find('input').eq(inputidx++).val()
+                } else if ( $(this).is('select') ) {
+                  htmlData += $cell.find('select option:selected').eq(selectidx++).text()
+                } else {
+                  if ( typeof $(this).html() === 'undefined' ) {
+                    htmlData += $(this).text()
+                  } else if ( jQuery().bootstrapTable === undefined || $(this).hasClass('filterControl') !== true ) {
+                    htmlData += $(this).html()
+                  }
+                }
+              })
+            }
+          }
+
+          if (defaults.htmlContent === true) {
+            result = $.trim(htmlData)
+          } else if (htmlData != '') {
+            let text = htmlData.replace(/\n/g, '\u2028').replace(/<br\s*[\/]?>/gi, '\u2060')
+            const obj = $('<div/>').html(text).contents()
+            text = ''
+            $.each(obj.text().split('\u2028'), function(i, v) {
+              if (i > 0) {
+                text += ' '
+              }
+              text += $.trim(v)
+            })
+
+            $.each(text.split('\u2060'), function(i, v) {
+              if (i > 0) {
+                result += '\n'
+              }
+              result += $.trim(v).replace(/\u00AD/g, '') // remove soft hyphens
+            })
+
+            if (defaults.type == 'json' ||
+                            (defaults.type === 'excel' && defaults.excelFileFormat === 'xmlss') ||
+                            defaults.numbers.output === false) {
+              var number = parseNumber(result)
+
+              if (number !== false) {
+                result = Number(number)
+              }
+            } else if (defaults.numbers.html.decimalMark != defaults.numbers.output.decimalMark ||
+                            defaults.numbers.html.thousandsSeparator != defaults.numbers.output.thousandsSeparator) {
+              var number = parseNumber(result)
+
+              if ( number !== false ) {
+                const frac = ('' + number).split('.')
+                if ( frac.length == 1 ) {
+                  frac[1] = ''
+                }
+                const mod = frac[0].length > 3 ? frac[0].length % 3 : 0
+
+                result = (defaults.numbers.output.thousandsSeparator ? ((mod ? frac[0].substr(0, mod) + defaults.numbers.output.thousandsSeparator : '') + frac[0].substr(mod).replace(/(\d{3})(?=\d)/g, '$1' + defaults.numbers.output.thousandsSeparator)) : frac[0]) +
+                                    (frac[1].length ? defaults.numbers.output.decimalMark + frac[1] : '')
+              }
+            }
+          }
+
+          if (defaults.escape === true) {
+            result = escape(result)
+          }
+
+          if (typeof defaults.onCellData === 'function') {
+            result = defaults.onCellData($cell, rowIndex, colIndex, result)
+          }
+        }
+
+        return result
+      }
+
+      function hyphenate(a, b, c) {
+        return b + '-' + c.toLowerCase()
+      }
+
+      function rgb2array(rgb_string, default_result) {
+        const re = /^rgb\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)$/
+        const bits = re.exec(rgb_string)
+        let result = default_result
+        if (bits) {
+          result = [parseInt(bits[1]), parseInt(bits[2]), parseInt(bits[3])]
+        }
+        return result
+      }
+
+      function getCellStyles(cell) {
+        let a = getStyle(cell, 'text-align')
+        const fw = getStyle(cell, 'font-weight')
+        const fs = getStyle(cell, 'font-style')
+        let f = ''
+        if (a == 'start') {
+          a = getStyle(cell, 'direction') == 'rtl' ? 'right' : 'left'
+        }
+        if (fw >= 700) {
+          f = 'bold'
+        }
+        if (fs == 'italic') {
+          f += fs
+        }
+        if (f === '') {
+          f = 'normal'
+        }
+
+        const result = {
+          style: {
+            align: a,
+            bcolor: rgb2array(getStyle(cell, 'background-color'), [255, 255, 255]),
+            color: rgb2array(getStyle(cell, 'color'), [0, 0, 0]),
+            fstyle: f
+          },
+          colspan: (parseInt($(cell).attr('colspan')) || 0),
+          rowspan: (parseInt($(cell).attr('rowspan')) || 0)
+        }
+
+        if (cell !== null) {
+          const r = cell.getBoundingClientRect()
+          result.rect = {
+            width: r.width,
+            height: r.height
+          }
+        }
+
+        return result
+      }
+
+      // get computed style property
+      function getStyle(target, prop) {
+        try {
+          if (window.getComputedStyle) { // gecko and webkit
+            prop = prop.replace(/([a-z])([A-Z])/, hyphenate) // requires hyphenated, not camel
+            return window.getComputedStyle(target, null).getPropertyValue(prop)
+          }
+          if (target.currentStyle) { // ie
+            return target.currentStyle[prop]
+          }
+          return target.style[prop]
+        } catch (e) {
+        }
+        return ''
+      }
+
+      function getUnitValue(parent, value, unit) {
+        const baseline = 100 // any number serves
+
+        const temp = document.createElement('div') // create temporary element
+        temp.style.overflow = 'hidden' // in case baseline is set too low
+        temp.style.visibility = 'hidden' // no need to show it
+
+        parent.appendChild(temp) // insert it into the parent for em, ex and %
+
+        temp.style.width = baseline + unit
+        const factor = baseline / temp.offsetWidth
+
+        parent.removeChild(temp) // clean up
+
+        return (value * factor)
+      }
+
+      function getPropertyUnitValue(target, prop, unit) {
+        const value = getStyle(target, prop) // get the computed style value
+
+        let numeric = value.match(/\d+/) // get the numeric component
+        if (numeric !== null) {
+          numeric = numeric[0] // get the string
+
+          return getUnitValue(target.parentElement, numeric, unit)
+        }
+        return 0
+      }
+
+      function jx_Workbook() {
+        if (!(this instanceof jx_Workbook)) return new jx_Workbook()
+        this.SheetNames = []
+        this.Sheets = {}
+      }
+
+      function jx_s2ab(s) {
+        const buf = new ArrayBuffer(s.length)
+        const view = new Uint8Array(buf)
+        for (let i = 0; i != s.length; ++i) view[i] = s.charCodeAt(i) & 0xFF
+        return buf
+      }
+
+      function jx_datenum(v, date1904) {
+        if (date1904) v += 1462
+        const epoch = Date.parse(v)
+        return (epoch - new Date(Date.UTC(1899, 11, 30))) / (24 * 60 * 60 * 1000)
+      }
+
+      function jx_createSheet(data) {
+        const ws = {}
+        const range = {
+          s: {
+            c: 10000000,
+            r: 10000000
+          },
+          e: {
+            c: 0,
+            r: 0
+          }
+        }
+        for (let R = 0; R != data.length; ++R) {
+          for (let C = 0; C != data[R].length; ++C) {
+            if (range.s.r > R) range.s.r = R
+            if (range.s.c > C) range.s.c = C
+            if (range.e.r < R) range.e.r = R
+            if (range.e.c < C) range.e.c = C
+            const cell = {
+              v: data[R][C]
+            }
+            if (cell.v === null) continue
+            const cell_ref = XLSX.utils.encode_cell({
+              c: C,
+              r: R
+            })
+
+            if (typeof cell.v === 'number') cell.t = 'n'
+            else if (typeof cell.v === 'boolean') cell.t = 'b'
+            else if (cell.v instanceof Date) {
+              cell.t = 'n'; cell.z = XLSX.SSF._table[14]
+              cell.v = jx_datenum(cell.v)
+            } else cell.t = 's'
+            ws[cell_ref] = cell
+          }
+        }
+
+        if (range.s.c < 10000000) ws['!ref'] = XLSX.utils.encode_range(range)
+        return ws
+      }
+
+      function strHashCode(str) {
+        let hash = 0; let i; let chr; let len
+        if (str.length === 0) return hash
+        for (i = 0, len = str.length; i < len; i++) {
+          chr = str.charCodeAt(i)
+          hash = ((hash << 5) - hash) + chr
+          hash |= 0 // Convert to 32bit integer
+        }
+        return hash
+      }
+
+      function downloadFile(filename, header, data) {
+        const ua = window.navigator.userAgent
+        if (filename !== false && (ua.indexOf('MSIE ') > 0 || !!ua.match(/Trident.*rv\:11\./))) {
+          if (window.navigator.msSaveOrOpenBlob) {
+            window.navigator.msSaveOrOpenBlob(new Blob([data]), filename)
+          } else {
+            // Internet Explorer (<= 9) workaround by Darryl (https://github.com/dawiong/tableExport.jquery.plugin)
+            // based on sampopes answer on http://stackoverflow.com/questions/22317951
+            // ! Not working for json and pdf format !
+            const frame = document.createElement('iframe')
+
+            if (frame) {
+              document.body.appendChild(frame)
+              frame.setAttribute('style', 'display:none')
+              frame.contentDocument.open('txt/html', 'replace')
+              frame.contentDocument.write(data)
+              frame.contentDocument.close()
+              frame.focus()
+
+              frame.contentDocument.execCommand('SaveAs', true, filename)
+              document.body.removeChild(frame)
+            }
+          }
+        } else {
+          const DownloadLink = document.createElement('a')
+
+          if (DownloadLink) {
+            let blobUrl = null
+
+            DownloadLink.style.display = 'none'
+            if (filename !== false) {
+              DownloadLink.download = filename
+            } else {
+              DownloadLink.target = '_blank'
+            }
+
+            if ( typeof data == 'object' ) {
+              blobUrl = window.URL.createObjectURL(data)
+              DownloadLink.href = blobUrl
+            } else if (header.toLowerCase().indexOf('base64,') >= 0) {
+              DownloadLink.href = header + base64encode(data)
+            } else {
+              DownloadLink.href = header + encodeURIComponent(data)
+            }
+
+            document.body.appendChild(DownloadLink)
+
+            if (document.createEvent) {
+              if (DownloadEvt === null) {
+                DownloadEvt = document.createEvent('MouseEvents')
+              }
+
+              DownloadEvt.initEvent('click', true, false)
+              DownloadLink.dispatchEvent(DownloadEvt)
+            } else if (document.createEventObject) {
+              DownloadLink.fireEvent('onclick')
+            } else if (typeof DownloadLink.onclick == 'function') {
+              DownloadLink.onclick()
+            }
+
+            if (blobUrl) {
+              window.URL.revokeObjectURL(blobUrl)
+            }
+
+            document.body.removeChild(DownloadLink)
+          }
+        }
+      }
+
+      function utf8Encode(string) {
+        string = string.replace(/\x0d\x0a/g, '\x0a')
+        let utftext = ''
+        for (let n = 0; n < string.length; n++) {
+          const c = string.charCodeAt(n)
+          if (c < 128) {
+            utftext += String.fromCharCode(c)
+          } else if ((c > 127) && (c < 2048)) {
+            utftext += String.fromCharCode((c >> 6) | 192)
+            utftext += String.fromCharCode((c & 63) | 128)
+          } else {
+            utftext += String.fromCharCode((c >> 12) | 224)
+            utftext += String.fromCharCode(((c >> 6) & 63) | 128)
+            utftext += String.fromCharCode((c & 63) | 128)
+          }
+        }
+        return utftext
+      }
+
+      function base64encode(input) {
+        const keyStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='
+        let output = ''
+        let chr1; let chr2; let chr3; let enc1; let enc2; let enc3; let enc4
+        let i = 0
+        input = utf8Encode(input)
+        while (i < input.length) {
+          chr1 = input.charCodeAt(i++)
+          chr2 = input.charCodeAt(i++)
+          chr3 = input.charCodeAt(i++)
+          enc1 = chr1 >> 2
+          enc2 = ((chr1 & 3) << 4) | (chr2 >> 4)
+          enc3 = ((chr2 & 15) << 2) | (chr3 >> 6)
+          enc4 = chr3 & 63
+          if (isNaN(chr2)) {
+            enc3 = enc4 = 64
+          } else if (isNaN(chr3)) {
+            enc4 = 64
+          }
+          output = output +
+                        keyStr.charAt(enc1) + keyStr.charAt(enc2) +
+                        keyStr.charAt(enc3) + keyStr.charAt(enc4)
+        }
+        return output
+      }
+
+      return this
+    }
+  })
+})(jQuery)

--- a/src/main/resources/react4xp/_entries/Table.jsx
+++ b/src/main/resources/react4xp/_entries/Table.jsx
@@ -4,9 +4,8 @@ import { Dropdown, Link } from '@statisticsnorway/ssb-component-library'
 import { isEmpty } from 'ramda'
 import MediaQuery from 'react-responsive'
 
-import '../../assets/js/jquery-global.js'
-import 'tableexport.jquery.plugin/libs/FileSaver/FileSaver.min.js'
-import 'tableexport.jquery.plugin/tableExport.min.js'
+import '../../assets/js/jquery-global'
+import '../../assets/js/tableExport'
 
 class Table extends React.Component {
   downloadTableAsCSV() {


### PR DESCRIPTION
- Uses the copy of the tableExport plugin source code from ssbno 4.7. instead of the npm package. 