### PR TITLE
Mimir 107 associated statistics and article archives

### DIFF
--- a/src/main/resources/assets/styles/_article.scss
+++ b/src/main/resources/assets/styles/_article.scss
@@ -104,41 +104,4 @@
       padding-left: 0 !important;
     }
   }
-
-  #dividerId {
-    @include make-row;
-
-    & > * {
-      margin-top: $spacer * 4;
-
-      @include media-breakpoint-down(md) {
-        @include make-col-ready();
-        @include make-col(12);
-      }
-    }
-
-    @include media-breakpoint-up(lg) {
-      margin: 0;
-    }
-  }
-
-  .as-aa-links-wrapper {
-    @include make-row;
-    margin-top: $spacer * 1;
-
-    &:first-child {
-      margin-top: $spacer * 2.5;
-    }
-
-    & > * {
-      @include make-col-ready();
-      @include make-col(12);
-
-      margin-top: $spacer * 1;
-
-      @include media-breakpoint-down(md) {
-        padding: 0;
-      }
-    }
-  }
 }

--- a/src/main/resources/assets/styles/_associatedArticleArchives.scss
+++ b/src/main/resources/assets/styles/_associatedArticleArchives.scss
@@ -1,0 +1,19 @@
+.part-associated-article-archives {
+  @include make-row;
+
+  margin-top: $spacer * 2.5;
+  padding: 0;
+
+  & > * {
+    @include make-col-ready();
+    @include make-col(12);
+  }
+
+  .associated-article-archives-links {
+    margin-top: $spacer * 0.5;
+
+    & > * {
+      margin-bottom: $spacer * 1;
+    }
+  }
+}

--- a/src/main/resources/assets/styles/_associatedStatistics.scss
+++ b/src/main/resources/assets/styles/_associatedStatistics.scss
@@ -1,0 +1,19 @@
+.part-associated-statistics {
+  @include make-row;
+
+  margin-top: $spacer * 2.5;
+  padding: 0;
+
+  & > * {
+    @include make-col-ready();
+    @include make-col(12);
+  }
+
+  .associated-statistics-links {
+    margin-top: $spacer * 0.5;
+
+    & > * {
+      margin-bottom: $spacer * 1;
+    }
+  }
+}

--- a/src/main/resources/assets/styles/main.scss
+++ b/src/main/resources/assets/styles/main.scss
@@ -60,6 +60,8 @@ $container-max-widths: (
 @import "./statbankLinkList";
 @import "./attachmentTablesFigures";
 @import "./omStatistikken";
+@import "./associatedStatistics";
+@import "./associatedArticleArchives";
 
 body {
   -moz-osx-font-smoothing: grayscale;

--- a/src/main/resources/site/i18n/phrases.properties
+++ b/src/main/resources/site/i18n/phrases.properties
@@ -117,7 +117,7 @@ XML_TO_JSON = Konverter xml til json
 
 articleName = Artikkel
 associatedStatisticsHeader = Tallene er hentet fra
-articleArchiveInArticleHeader = Artikkelen er en del av serien
+associatedArticleArchivesHeader = Artikkelen er en del av serien
 relatedArticlesHeading = Analyser, artikler og publikasjoner
 relatedFactPagesHeading = Faktasider
 externalLinksHeading = Andre nettsteder

--- a/src/main/resources/site/i18n/phrases_en.properties
+++ b/src/main/resources/site/i18n/phrases_en.properties
@@ -117,7 +117,7 @@ XML_TO_JSON = Convert xml to json
 
 articleName = Article
 associatedStatisticsHeader = Full set of figures
-articleArchiveInArticleHeader = Series archive
+associatedArticleArchivesHeader = Series archive
 relatedArticlesHeading = Analyzes, articles and publications
 relatedFactPagesHeading = Fact pages
 externalLinksHeading = Other websites

--- a/src/main/resources/site/i18n/phrases_no.properties
+++ b/src/main/resources/site/i18n/phrases_no.properties
@@ -115,7 +115,7 @@ XML_TO_JSON = Konverter xml til json
 
 articleName = Artikkel
 associatedStatisticsHeader = Tallene er hentet fra
-articleArchiveInArticleHeader = Artikkelen er en del av serien
+associatedArticleArchivesHeader = Artikkelen er en del av serien
 relatedArticlesHeading = Analyser, artikler og publikasjoner
 relatedFactPagesHeading = Faktasider
 externalLinksHeading = Andre nettsteder

--- a/src/main/resources/site/parts/article/article.es6
+++ b/src/main/resources/site/parts/article/article.es6
@@ -2,14 +2,8 @@ const {
   data
 } = __non_webpack_require__('/lib/util')
 const {
-  get
-} = __non_webpack_require__( '/lib/xp/content')
-const {
-  getContent, pageUrl, processHtml
+  getContent, processHtml
 } = __non_webpack_require__('/lib/xp/portal')
-const {
-  getPhrases
-} = __non_webpack_require__( '/lib/language')
 const {
   render
 } = __non_webpack_require__('/lib/thymeleaf')
@@ -19,7 +13,6 @@ const {
 
 const languageLib = __non_webpack_require__( '/lib/language')
 const moment = require('moment/min/moment-with-locales')
-const React4xp = __non_webpack_require__('/lib/enonic/react4xp')
 const view = resolve('./article.html')
 
 exports.get = (req) => {
@@ -33,7 +26,6 @@ exports.get = (req) => {
 function renderPart(req) {
   const page = getContent()
   moment.locale(page.language ? page.language : 'nb')
-  const phrases = getPhrases(page)
 
   const bodyText = processHtml({
     value: page.data.articleText ? page.data.articleText.replace(/&nbsp;/g, ' ') : undefined
@@ -57,20 +49,6 @@ function renderPart(req) {
     }
   })
 
-  const divider = new React4xp('Divider')
-    .setProps({
-      dark: true
-    })
-    .setId('dividerId')
-
-  const associatedStatisticsHeader = phrases.associatedStatisticsHeader
-  const associatedStatisticsConfig = page.data.associatedStatistics ? data.forceArray(page.data.associatedStatistics) : []
-  const associatedStatistics = getAssociatedStatisticsLinks(associatedStatisticsConfig)
-
-  const articleArchiveInArticleHeader = phrases.articleArchiveInArticleHeader
-  const articleArchivesConfig = page.data.articleArchive ? data.forceArray(page.data.articleArchive) : []
-  const articleArchives = getArticleArchiveLinks(articleArchivesConfig)
-
   const model = {
     title: page.displayName,
     language: languageLib.getLanguage(page),
@@ -80,66 +58,14 @@ function renderPart(req) {
     pubDate,
     modifiedDate,
     authors,
-    associatedStatisticsHeader,
-    associatedStatistics,
-    articleArchiveInArticleHeader,
-    articleArchives,
     serialNumber: page.data.serialNumber,
     introTitle: page.data.introTitle
   }
 
   const body = render(view, model)
-  const dividerBody = divider.renderBody({
-    body
-  })
 
   return {
-    body: (associatedStatistics.length > 0 || articleArchives.length > 0) ? dividerBody : body,
+    body,
     contentType: 'text/html'
   }
-}
-
-const getAssociatedStatisticsLinks = (associatedStatisticsConfig) => {
-  if (associatedStatisticsConfig.length > 0) {
-    return associatedStatisticsConfig.map((option) => {
-      if (option._selected === 'XP') {
-        const associatedStatisticsXP = option.XP.content
-        const associatedStatisticsXPContent = get({
-          key: associatedStatisticsXP
-        })
-
-        return {
-          title: associatedStatisticsXPContent.displayName,
-          href: pageUrl({
-            id: associatedStatisticsXP
-          })
-        }
-      } else if (option._selected === 'CMS') {
-        const associatedStatisticsCMS = option.CMS
-
-        return {
-          ...associatedStatisticsCMS
-        }
-      }
-    })
-  }
-  return []
-}
-
-const getArticleArchiveLinks = (articleArchivesConfig) => {
-  if (articleArchivesConfig.length > 0) {
-    return articleArchivesConfig.map((articleArchive) => {
-      const articleArchiveContent = get({
-        key: articleArchive
-      })
-
-      return {
-        title: articleArchiveContent.displayName,
-        href: pageUrl({
-          id: articleArchive
-        })
-      }
-    })
-  }
-  return []
 }

--- a/src/main/resources/site/parts/article/article.html
+++ b/src/main/resources/site/parts/article/article.html
@@ -34,25 +34,6 @@
         </div>
         <div class="col-12 p-0">
             <div class="article-body" data-th-utext="${bodyText}" />
-            <section id="dividerId" class="xp-part part-divider"></section>
-        </div>
-        <div class="col-12 p-0">
-            <div data-th-if="${#lists.size(associatedStatistics) >= 1}" class="as-aa-links-wrapper">
-                <h3 data-th-text="${associatedStatisticsHeader}" />
-                <div data-th-each="associatedStatistic : ${associatedStatistics}">
-                    <p data-th-if="${associatedStatistic.title}">
-                        <a data-th-href="${associatedStatistic.href}" data-th-text="${associatedStatistic.title}" />
-                    </p>
-                </div>
-            </div>
-            <div data-th-if="${#lists.size(articleArchives) >= 1}" class="as-aa-links-wrapper">
-                <h3 data-th-text="${articleArchiveInArticleHeader}" />
-                <div data-th-each="articleArchive : ${articleArchives}">
-                    <p data-th-if="${articleArchive.title}">
-                        <a data-th-href="${articleArchive.href}" data-th-text="${articleArchive.title}" />
-                    </p>
-                </div>
-            </div>
         </div>
     </div>
 </section>

--- a/src/main/resources/site/parts/associatedArticleArchives/associatedArticleArchives.es6
+++ b/src/main/resources/site/parts/associatedArticleArchives/associatedArticleArchives.es6
@@ -58,12 +58,9 @@ function renderPart(req) {
 
   const associatedArticleArchiveLinksComponent = new React4xp('Links')
     .setProps({
-      links: associatedArticleArchiveLinks.map(({
-        title, href
-      }) => {
+      links: associatedArticleArchiveLinks.map((articleArchiveLinks) => {
         return {
-          children: title,
-          href
+          ...articleArchiveLinks
         }
       })
     })
@@ -74,18 +71,11 @@ function renderPart(req) {
     associatedArticleArchiveLinksId: associatedArticleArchiveLinksComponent.react4xpId
   })
 
-  const isOutsideContentStudio = (
-    req.mode === 'live' || req.mode === 'preview'
-  )
-
   return {
     body: associatedArticleArchiveLinksComponent.renderBody({
-      body,
-      clientRender: isOutsideContentStudio
+      body
     }),
-    pageContributions: associatedArticleArchiveLinksComponent.renderPageContributions({
-      clientRender: isOutsideContentStudio
-    }),
+    pageContributions: associatedArticleArchiveLinksComponent.renderPageContributions(),
     contentType: 'text/html'
   }
 }
@@ -97,13 +87,16 @@ const getAssociatedArticleArchiveLinks = (associatedArticleArchivesConfig) => {
         key: articleArchive
       })
 
-      return {
-        title: articleArchiveContent.displayName,
-        href: pageUrl({
-          id: articleArchive
-        })
+      if (articleArchiveContent) {
+        return {
+          children: articleArchiveContent.displayName,
+          href: pageUrl({
+            id: articleArchive
+          })
+        }
       }
-    })
+      return null
+    }).filter((articleArchive) => !!articleArchive)
   }
   return []
 }

--- a/src/main/resources/site/parts/associatedArticleArchives/associatedArticleArchives.es6
+++ b/src/main/resources/site/parts/associatedArticleArchives/associatedArticleArchives.es6
@@ -1,0 +1,109 @@
+const {
+  data: {
+    forceArray
+  }
+} = __non_webpack_require__('/lib/util')
+const {
+  get
+} = __non_webpack_require__( '/lib/xp/content')
+const {
+  getContent, pageUrl
+} = __non_webpack_require__('/lib/xp/portal')
+const {
+  getPhrases
+} = __non_webpack_require__( '/lib/language')
+const {
+  render
+} = __non_webpack_require__('/lib/thymeleaf')
+const {
+  renderError
+} = __non_webpack_require__('/lib/error/error')
+
+const moment = require('moment/min/moment-with-locales')
+const React4xp = __non_webpack_require__('/lib/enonic/react4xp')
+const view = resolve('./associatedArticleArchives.html')
+
+exports.get = (req) => {
+  try {
+    return renderPart(req)
+  } catch (e) {
+    return renderError(req, 'Error in part: ', e)
+  }
+}
+
+exports.preview = (req) => renderPart(req)
+
+function renderPart(req) {
+  const page = getContent()
+  moment.locale(page.language ? page.language : 'nb')
+  const phrases = getPhrases(page)
+
+  const associatedArticleArchivesHeader = phrases.associatedArticleArchivesHeader
+  const associatedArticleArchivesConfig = page.data.articleArchive ? forceArray(page.data.articleArchive) : []
+  const associatedArticleArchiveLinks = getAssociatedArticleArchiveLinks(associatedArticleArchivesConfig)
+
+  if (!associatedArticleArchivesConfig.length > 0) {
+    if (req.mode === 'edit' && page.type !== `${app.name}:article`) {
+      return {
+        body: render(view, {
+          associatedArticleArchivesHeader
+        })
+      }
+    } else {
+      return {
+        body: null
+      }
+    }
+  }
+
+  const associatedArticleArchiveLinksComponent = new React4xp('Links')
+    .setProps({
+      links: associatedArticleArchiveLinks.map(({
+        title, href
+      }) => {
+        return {
+          children: title,
+          href
+        }
+      })
+    })
+    .uniqueId()
+
+  const body = render(view, {
+    associatedArticleArchivesHeader,
+    associatedArticleArchiveLinksId: associatedArticleArchiveLinksComponent.react4xpId
+  })
+
+  const isOutsideContentStudio = (
+    req.mode === 'live' || req.mode === 'preview'
+  )
+
+  return {
+    body: associatedArticleArchiveLinksComponent.renderBody({
+      body,
+      clientRender: isOutsideContentStudio
+    }),
+    pageContributions: associatedArticleArchiveLinksComponent.renderPageContributions({
+      clientRender: isOutsideContentStudio
+    }),
+    contentType: 'text/html'
+  }
+}
+
+const getAssociatedArticleArchiveLinks = (associatedArticleArchivesConfig) => {
+  if (associatedArticleArchivesConfig.length > 0) {
+    return associatedArticleArchivesConfig.map((articleArchive) => {
+      const articleArchiveContent = get({
+        key: articleArchive
+      })
+
+      return {
+        title: articleArchiveContent.displayName,
+        href: pageUrl({
+          id: articleArchive
+        })
+      }
+    })
+  }
+  return []
+}

--- a/src/main/resources/site/parts/associatedArticleArchives/associatedArticleArchives.html
+++ b/src/main/resources/site/parts/associatedArticleArchives/associatedArticleArchives.html
@@ -1,0 +1,4 @@
+<section class="xp-part part-associated-article-archives container-fluid">
+    <h3 data-th-if="${associatedArticleArchivesHeader}" data-th-text="${associatedArticleArchivesHeader}" />
+    <div class="associated-article-archives-links" data-th-id="${associatedArticleArchiveLinksId}"></div>
+</section>

--- a/src/main/resources/site/parts/associatedArticleArchives/associatedArticleArchives.xml
+++ b/src/main/resources/site/parts/associatedArticleArchives/associatedArticleArchives.xml
@@ -1,0 +1,3 @@
+<part>
+    <display-name>Tilhørende artikkelarkiv</display-name>
+</part>

--- a/src/main/resources/site/parts/associatedStatistics/associatedStatistics.es6
+++ b/src/main/resources/site/parts/associatedStatistics/associatedStatistics.es6
@@ -1,0 +1,118 @@
+const {
+  data: {
+    forceArray
+  }
+} = __non_webpack_require__('/lib/util')
+const {
+  get
+} = __non_webpack_require__( '/lib/xp/content')
+const {
+  getContent, pageUrl
+} = __non_webpack_require__('/lib/xp/portal')
+const {
+  getPhrases
+} = __non_webpack_require__( '/lib/language')
+const {
+  render
+} = __non_webpack_require__('/lib/thymeleaf')
+const {
+  renderError
+} = __non_webpack_require__('/lib/error/error')
+
+const moment = require('moment/min/moment-with-locales')
+const React4xp = __non_webpack_require__('/lib/enonic/react4xp')
+const view = resolve('./associatedStatistics.html')
+
+exports.get = (req) => {
+  try {
+    return renderPart(req)
+  } catch (e) {
+    return renderError(req, 'Error in part: ', e)
+  }
+}
+
+exports.preview = (req) => renderPart(req)
+
+function renderPart(req) {
+  const page = getContent()
+  moment.locale(page.language ? page.language : 'nb')
+  const phrases = getPhrases(page)
+
+  const associatedStatisticsHeader = phrases.associatedStatisticsHeader
+  const associatedStatisticsConfig = page.data.associatedStatistics ? forceArray(page.data.associatedStatistics) : []
+  const associatedStatisticsLinks = getAssociatedStatisticsLinks(associatedStatisticsConfig)
+
+  if (!associatedStatisticsConfig.length > 0) {
+    if (req.mode === 'edit' && page.type !== `${app.name}:article`) {
+      return {
+        body: render(view, {
+          associatedStatisticsHeader
+        })
+      }
+    } else {
+      return {
+        body: null
+      }
+    }
+  }
+
+  const associatedStatisticsLinksComponent = new React4xp('Links')
+    .setProps({
+      links: associatedStatisticsLinks.map(({
+        title, href
+      }) => {
+        return {
+          children: title,
+          href
+        }
+      })
+    })
+    .uniqueId()
+
+  const body = render(view, {
+    associatedStatisticsHeader,
+    associatedStatisticsLinksId: associatedStatisticsLinksComponent.react4xpId
+  })
+
+  const isOutsideContentStudio = (
+    req.mode === 'live' || req.mode === 'preview'
+  )
+
+  return {
+    body: associatedStatisticsLinksComponent.renderBody({
+      body,
+      clientRender: isOutsideContentStudio
+    }),
+    pageContributions: associatedStatisticsLinksComponent.renderPageContributions({
+      clientRender: isOutsideContentStudio
+    }),
+    contentType: 'text/html'
+  }
+}
+
+const getAssociatedStatisticsLinks = (associatedStatisticsConfig) => {
+  if (associatedStatisticsConfig.length > 0) {
+    return associatedStatisticsConfig.map((option) => {
+      if (option._selected === 'XP') {
+        const associatedStatisticsXP = option.XP.content
+        const associatedStatisticsXPContent = get({
+          key: associatedStatisticsXP
+        })
+
+        return {
+          title: associatedStatisticsXPContent.displayName,
+          href: pageUrl({
+            id: associatedStatisticsXP
+          })
+        }
+      } else if (option._selected === 'CMS') {
+        const associatedStatisticsCMS = option.CMS
+
+        return {
+          ...associatedStatisticsCMS
+        }
+      }
+    })
+  }
+  return []
+}

--- a/src/main/resources/site/parts/associatedStatistics/associatedStatistics.es6
+++ b/src/main/resources/site/parts/associatedStatistics/associatedStatistics.es6
@@ -58,12 +58,9 @@ function renderPart(req) {
 
   const associatedStatisticsLinksComponent = new React4xp('Links')
     .setProps({
-      links: associatedStatisticsLinks.map(({
-        title, href
-      }) => {
+      links: associatedStatisticsLinks.map((statistics) => {
         return {
-          children: title,
-          href
+          ...statistics
         }
       })
     })
@@ -94,7 +91,7 @@ const getAssociatedStatisticsLinks = (associatedStatisticsConfig) => {
 
         if (associatedStatisticsXPContent) {
           return {
-            title: associatedStatisticsXPContent.displayName,
+            children: associatedStatisticsXPContent.displayName,
             href: pageUrl({
               id: associatedStatisticsXP
             })
@@ -105,7 +102,8 @@ const getAssociatedStatisticsLinks = (associatedStatisticsConfig) => {
         const associatedStatisticsCMS = option.CMS
 
         return {
-          ...associatedStatisticsCMS
+          children: associatedStatisticsCMS.title,
+          href: associatedStatisticsCMS.href
         }
       }
     }).filter((statistics) => !!statistics)

--- a/src/main/resources/site/parts/associatedStatistics/associatedStatistics.es6
+++ b/src/main/resources/site/parts/associatedStatistics/associatedStatistics.es6
@@ -74,18 +74,11 @@ function renderPart(req) {
     associatedStatisticsLinksId: associatedStatisticsLinksComponent.react4xpId
   })
 
-  const isOutsideContentStudio = (
-    req.mode === 'live' || req.mode === 'preview'
-  )
-
   return {
     body: associatedStatisticsLinksComponent.renderBody({
-      body,
-      clientRender: isOutsideContentStudio
+      body
     }),
-    pageContributions: associatedStatisticsLinksComponent.renderPageContributions({
-      clientRender: isOutsideContentStudio
-    }),
+    pageContributions: associatedStatisticsLinksComponent.renderPageContributions(),
     contentType: 'text/html'
   }
 }

--- a/src/main/resources/site/parts/associatedStatistics/associatedStatistics.es6
+++ b/src/main/resources/site/parts/associatedStatistics/associatedStatistics.es6
@@ -92,12 +92,15 @@ const getAssociatedStatisticsLinks = (associatedStatisticsConfig) => {
           key: associatedStatisticsXP
         })
 
-        return {
-          title: associatedStatisticsXPContent.displayName,
-          href: pageUrl({
-            id: associatedStatisticsXP
-          })
+        if (associatedStatisticsXPContent) {
+          return {
+            title: associatedStatisticsXPContent.displayName,
+            href: pageUrl({
+              id: associatedStatisticsXP
+            })
+          }
         }
+        return null
       } else if (option._selected === 'CMS') {
         const associatedStatisticsCMS = option.CMS
 
@@ -105,7 +108,7 @@ const getAssociatedStatisticsLinks = (associatedStatisticsConfig) => {
           ...associatedStatisticsCMS
         }
       }
-    })
+    }).filter((statistics) => !!statistics)
   }
   return []
 }

--- a/src/main/resources/site/parts/associatedStatistics/associatedStatistics.html
+++ b/src/main/resources/site/parts/associatedStatistics/associatedStatistics.html
@@ -1,0 +1,4 @@
+<section class="xp-part part-associated-statistics container-fluid">
+    <h3 data-th-if="${associatedStatisticsHeader}" data-th-text="${associatedStatisticsHeader}"></h3>
+    <div class="associated-statistics-links" data-th-id="${associatedStatisticsLinksId}"></div>
+</section>

--- a/src/main/resources/site/parts/associatedStatistics/associatedStatistics.xml
+++ b/src/main/resources/site/parts/associatedStatistics/associatedStatistics.xml
@@ -1,0 +1,3 @@
+<part>
+    <display-name>Tilhørende statistikker</display-name>
+</part>


### PR DESCRIPTION
- Moves associated statistics and article archives code from article part to their new respective parts; associatedStatistics and associatedArticleArchives.
- Removes divider and other unnecessary code (imports previously used on code that is no longer there) from article part.
- Uses Links react component for the associated statistics and article archive links.