### PR TITLE
MIMIR-145 fix keyfigures unpublished alert

### DIFF
--- a/src/main/resources/react4xp/_entries/KeyFigure.jsx
+++ b/src/main/resources/react4xp/_entries/KeyFigure.jsx
@@ -39,21 +39,25 @@ class KeyFigures extends React.Component {
   }
 
   addPreviewInfo() {
+    const keyFigures = this.state.keyFigures
+
     if (this.props.showPreviewDraft) {
       if (this.state.fetchUnPublished) {
-        if (this.props.draftExist) {
-          return (
-            <Alert variant='info' className="mb-4">
+        return keyFigures.map((keyFigure) => {
+          if (this.props.draftExist && keyFigure.number) {
+            return (
+              <Alert variant='info' className="mb-4">
                   Tallet i nøkkeltallet nedenfor er upublisert
-            </Alert>
-          )
-        } else {
-          return (
-            <Alert variant='warning' className="mb-4">
+              </Alert>
+            )
+          } else {
+            return (
+              <Alert variant='warning' className="mb-4">
                   Finnes ikke upubliserte tall for dette nøkkeltallet
-            </Alert>
-          )
-        }
+              </Alert>
+            )
+          }
+        })
       }
     }
     return


### PR DESCRIPTION
- Adds a conditional check for keyFigures addPreviewInfo to return alert variant warning when the number prop in keyFigures is empty.