### PR TITLE
Mimir 367 create mabl branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,7 +37,7 @@ steps:
         from_secret: mabl-env-test
     commands:
       - npm install -g @mablhq/mabl-cli 
-      - mabl deployments create --api-key $MABL_API_KEY --application-id $MABL_APP_ID --labels MIMIR --environment-id $MABL_ENV_ID_TEST --revision $DRONE_COMMIT_SHA --await-completion --mabl-branch ${DRONE_SOURCE_BRANCH} --auto-branch true
+      - mabl deployments create --api-key $MABL_API_KEY --application-id $MABL_APP_ID --labels MIMIR --environment-id $MABL_ENV_ID_TEST --revision $DRONE_COMMIT_SHA --await-completion --mabl-branch ${DRONE_SOURCE_BRANCH}
 ---
 kind: pipeline
 type: docker

--- a/.github/workflows/create_mable_branch.yml
+++ b/.github/workflows/create_mable_branch.yml
@@ -1,0 +1,31 @@
+# This is a workflow
+
+name: CREATE MABL FEATURE BRANCH
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  pull_request:
+    types: [labeled]
+    branches: [mimir-367-dronecli]
+  workflow_dispatch:
+jobs:
+  # This workflow contains a single job called "create_mabl_branch"
+  create_mabl_branch:
+    if: ${{ github.event.label.name == 'run mabl test' }}
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # container
+    container: node:10.18-jessie
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: install mabl
+      run: npm install -g @mablhq/mabl-cli
+    - name: Branch name
+      run: echo running on branch ${GITHUB_HEAD_REF##*/} or ${GITHUB_REF##*/} with label ${{ github.event.label.name }}
+    - name: create mabl branch
+      env:
+        MABL_API_KEY: ${{ secrets.MABLAPIKEY }}
+      run: |
+        mabl auth activate-key $MABL_API_KEY
+        mabl branches create ${GITHUB_HEAD_REF##*/}

--- a/.github/workflows/create_mable_branch.yml
+++ b/.github/workflows/create_mable_branch.yml
@@ -7,7 +7,7 @@ name: CREATE MABL FEATURE BRANCH
 on:
   pull_request:
     types: [labeled]
-    branches: [mimir-367-dronecli]
+    branches: [master]
   workflow_dispatch:
 jobs:
   # This workflow contains a single job called "create_mabl_branch"

--- a/.github/workflows/create_mable_branch.yml
+++ b/.github/workflows/create_mable_branch.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     types: [labeled]
     branches: [master]
-  workflow_dispatch:
 jobs:
   # This workflow contains a single job called "create_mabl_branch"
   create_mabl_branch:


### PR DESCRIPTION
Endrer .drone.yml slik at mabl branch ikke blir auto-created ved kjøring av tester mot TEST. Lagt til en workflow som oppretter en mabl branch kun når 'run mabl test' label blir satt på PR 