### PR TITLE
Auto-assign should now only run when PR are opened

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,5 +1,7 @@
-name: 'Auto Assign'
-on: pull_request
+name: "Auto Assign"
+on:
+  pull_request:
+    types: [opened]
 
 jobs:
   add-reviews:


### PR DESCRIPTION
Added types: opened to action.yml. This should fix multiple assignees to the same PR.