### PR TITLE
Adds canonical url to all pages.

### DIFF
--- a/src/main/resources/site/pages/default/default.es6
+++ b/src/main/resources/site/pages/default/default.es6
@@ -241,8 +241,10 @@ exports.get = function(req) {
   const hideBreadcrumb = !!page.page.config.hide_breadcrumb
 
   const statbankFane = (req.params.xpframe === 'statbank')
-  // Fjerner /ssb fra starten av path
-  const pageUrl = page._path.substr(4)
+  const baseUrl = app.config && app.config['ssb.baseUrl'] ? app.config['ssb.baseUrl'] : 'https://www.ssb.no'
+
+  //Fjerner /ssb fra starten av path
+  const pageUrl = baseUrl + page._path.substr(4)
   const pageLanguage = page.language ? page.language : 'nb'
   const statbankHelpLink = getSiteConfig().statbankHelpLink
 

--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans%7COpen+Sans:700%7CRoboto:700%7CRoboto+Condensed:700"/>
   <link rel="stylesheet" data-th-href="${stylesUrl}"/>
   <link rel="alternate" data-th-if="${alternateLanguageVersionUrl}" data-th-href="${alternateLanguageVersionUrl}" data-th-hreflang="${language.alternate}"/>
+  <link data-th-unless="${statbankWeb}" rel="canonical" data-th-href="${pageUrl}" />
 
 </head>
 <body class="xp-page" data-th-classappend="${bodyClasses}">


### PR DESCRIPTION
We can not use the SEO app alternative, as the statbank and other frames would get the wrong path.
MIMIR-785