### PR TITLE
Oppdatert macro for staticVisualization for å inkludere dividers

### DIFF
--- a/src/main/resources/site/macros/staticVisualization/staticVisualization.ts
+++ b/src/main/resources/site/macros/staticVisualization/staticVisualization.ts
@@ -23,7 +23,7 @@ exports.macro = (context: MacroContext): Response | React4xpResponse => {
     const config: StaticVisualizationConfig = context.params
     const staticVisualization: Response = preview(context, config.staticVisualizationContent)
 
-    if (staticVisualization.status && staticVisualization.status !== 200) throw new Error(`Highchart with id ${config.staticVisualizationContent} missing`)
+    if (staticVisualization.status && staticVisualization.status !== 200) throw new Error(`StaticVisualization with id ${config.staticVisualizationContent} missing`)
     staticVisualization.body = divider.body as string + staticVisualization.body + divider.body
 
     return staticVisualization


### PR DESCRIPTION

Har oppdatert macro for "staticVisualization", slik at det følger de samme prinsippene som "HighChart" med hensyn til 'Dividers'.

Jeg brukte denne artikkel i content studio for å teste med Macros **eksempler/artikler/test-av-dividers-med-staticvisualization-og-highcharts**

Testes i lighthouse og Axe DevTools - kanskje noen tips om hvor viktig det er å fikse errors (for eksempel unique id's error)
![image](https://user-images.githubusercontent.com/77102634/185141329-40c8ceb7-ffab-4ff1-b031-bbf8ad2c7ad4.png)
