### PR TITLE
Update container version running node.js

### DIFF
--- a/.github/workflows/mabl_test.yml
+++ b/.github/workflows/mabl_test.yml
@@ -28,7 +28,7 @@ jobs:
   mabl_test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: node:10.18-jessie
+    container: node:lts
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Git checkout

--- a/.github/workflows/merge_mabl_feature_branch.yml
+++ b/.github/workflows/merge_mabl_feature_branch.yml
@@ -15,7 +15,7 @@ jobs:
   merge_mabl_branch:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: node:10.18-jessie
+    container: node:lts
     steps:
     - name: install mabl cli
       run: npm install -g @mablhq/mabl-cli


### PR DESCRIPTION
All Mabl workflows in github is failing because of being locked to an
old node.js version through the docker image tag.
This change updates the tag from "10.18-jessie" to the more generic
"lts".