### PR TITLE
Test Github Actions as CI/CD tool

### DIFF
--- a/.github/workflows/deploy_to_qa.yaml
+++ b/.github/workflows/deploy_to_qa.yaml
@@ -1,0 +1,108 @@
+name: 'Deploy to QA'
+on:
+  push:
+    branches:
+      - 'master'
+  
+jobs:
+  deploy_to_qa:
+    name: 'Deploy to AQ'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - id: build_app
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          skipPublishing: true
+      - id: deploy_app_to_XP
+        uses: 'enonic/action-app-deploy@main'
+        with: 
+          url: 'https://ssb-xp7q-admin.enonic.cloud:4443'
+          username: ${{ secrets.ENONIC_QA_USER }}
+          password: ${{ secrets.ENONIC_QA_PASS }}
+          client_cert: ${{ secrets.ENONIC_QA_CERT }}
+          client_key: ${{ secrets.ENONIC_QA_KEY }}
+          app_jar: "./build/libs/*.jar"
+      - name: Send success message to Slack
+        id: slack_success
+        if: success()
+        uses: slackapi/slack-github-action@v1
+        with:
+          # Using Github block kit (https://api.slack.com/reference/block-kit/blocks) to configure the Slack message, see https://docs.github.com/en/actions/learn-github-actions/contexts
+          # for more information about context variables
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                      "alt_text" : "Github logo"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Run by: *${{ github.actor }}* on: *${{ github.ref_name }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🛠 Build ${{ github.run_number }} is a *${{ job.status }}*, well done!\n<${{ github.event.pull_request.html_url || github.event.head_commit.url }}|Commit or PR>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send failure message to Slack
+        id: slack_failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                      "alt_text" : "Github logo"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Run by: *${{ github.actor }}* on: *${{ github.ref_name }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "💣 Build ${{ github.run_number }} is a *${{ job.status }}*, and that's cool!\nIf you want to fix it, start by looking at the <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow output>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/deploy_to_test.yaml
+++ b/.github/workflows/deploy_to_test.yaml
@@ -1,0 +1,106 @@
+name: 'Deploy to Test'
+on:
+  pull_request
+  
+jobs:
+  deploy_to_test:
+    name: 'Deploy to Test'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - id: build_app
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          skipPublishing: true
+      - id: deploy_app_to_XP
+        uses: 'enonic/action-app-deploy@main'
+        with: 
+          url: 'https://ssb-xp7t-admin.enonic.cloud:4443'
+          username: ${{ secrets.ENONIC_TEST_USER }}
+          password: ${{ secrets.ENONIC_TEST_PASS }}
+          client_cert: ${{ secrets.ENONIC_CERT }}
+          client_key: ${{ secrets.ENONIC_KEY }}
+          app_jar: "./build/libs/*.jar"
+      - name: Send success message to Slack
+        id: slack_success
+        if: success()
+        uses: slackapi/slack-github-action@v1
+        with:
+          # Using Github block kit (https://api.slack.com/reference/block-kit/blocks) to configure the Slack message, see https://docs.github.com/en/actions/learn-github-actions/contexts
+          # for more information about context variables
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                      "alt_text" : "Github logo"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Run by: *${{ github.actor }}* on: *${{ github.ref_name }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🛠 Build ${{ github.run_number }} is a *${{ job.status }}*, well done!\n<${{ github.event.pull_request.html_url || github.event.head_commit.url }}|Commit or PR>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Send failure message to Slack
+        id: slack_failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                      "alt_text" : "Github logo"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Run by: *${{ github.actor }}* on: *${{ github.ref_name }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "💣 Build ${{ github.run_number }} is a *${{ job.status }}*, and that's cool!\nIf you want to fix it, start by looking at the <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow output>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Github Actions is a recommended tool for the CI/CD prosess for Enonic XP.

This change creates two Workflows for Github Actions, one to build and deploy to the test environment when a new PR is opened; the other to build and deploy to QA environment when a change is pushed to the branch 'master'.

int.ref: [MIMIR-1227]

[MIMIR-1227]: https://statistics-norway.atlassian.net/browse/MIMIR-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ