### PR TITLE
Add mabl tests to github action

### DIFF
--- a/.github/workflows/deploy_to_qa.yaml
+++ b/.github/workflows/deploy_to_qa.yaml
@@ -6,7 +6,7 @@ on:
   
 jobs:
   deploy_to_qa:
-    name: 'Deploy to AQ'
+    name: 'Deploy to QA'
     runs-on: 'ubuntu-latest'
     steps:
       - id: build_app
@@ -16,7 +16,7 @@ jobs:
       - id: deploy_app_to_XP
         uses: 'enonic/action-app-deploy@main'
         with: 
-          url: 'https://ssb-xp7q-admin.enonic.cloud:4443'
+          url: ${{ secrets.ENONIC_QA_URL }}
           username: ${{ secrets.ENONIC_QA_USER }}
           password: ${{ secrets.ENONIC_QA_PASS }}
           client_cert: ${{ secrets.ENONIC_QA_CERT }}
@@ -106,3 +106,20 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  mabl_test:
+    # Run this job after deploy is finished, and only run if deploy succeeded
+    needs: deploy_to_test
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    runs-on: ubuntu-latest
+    container: node:lts
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Branch name and commit hash
+        run: |
+              echo running on branch ${GITHUB_HEAD_REF##*/} or ${GITHUB_REF##*/}
+              echo running $(echo $GITHUB_SHA | cut -c1-8) and ${GITHUB_SHA}
+      - name: install mabl
+        run: npm install -g @mablhq/mabl-cli
+      - name: mabl end-to-end test - TEST
+        run: mabl deployments create --api-key ${{ secrets.MABLAPIKEY }} --application-id ${{ secrets.MABLAPPID }} --environment-id ${{ secrets.MABLENVQA }} --labels MIMIR --await-completion

--- a/.github/workflows/deploy_to_test.yaml
+++ b/.github/workflows/deploy_to_test.yaml
@@ -1,6 +1,9 @@
 name: 'Deploy to Test'
 on:
-  pull_request
+  pull_request:
+  push:
+    branches:
+      - 'mabl-test-from-gha'
   
 jobs:
   deploy_to_test:
@@ -13,12 +16,13 @@ jobs:
           skipPublishing: true
       - id: deploy_app_to_XP
         uses: 'enonic/action-app-deploy@main'
-        with: 
-          url: 'https://ssb-xp7t-admin.enonic.cloud:4443'
+        with:
+          # Secrets from Github repository
+          url: ${{ secrets.ENONIC_TEST_URL }}
           username: ${{ secrets.ENONIC_TEST_USER }}
           password: ${{ secrets.ENONIC_TEST_PASS }}
-          client_cert: ${{ secrets.ENONIC_CERT }}
-          client_key: ${{ secrets.ENONIC_KEY }}
+          client_cert: ${{ secrets.ENONIC_TEST_CERT }}
+          client_key: ${{ secrets.ENONIC_TEST_KEY }}
           app_jar: "./build/libs/*.jar"
       - name: Send success message to Slack
         id: slack_success
@@ -104,3 +108,20 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  mabl_test:
+    # Run this job after deploy is finished, and only run if deploy succeeded
+    needs: deploy_to_test
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    runs-on: ubuntu-latest
+    container: node:lts
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Branch name and commit hash
+        run: |
+              echo running on branch ${GITHUB_HEAD_REF##*/} or ${GITHUB_REF##*/}
+              echo running $(echo $GITHUB_SHA | cut -c1-8) and ${GITHUB_SHA}
+      - name: install mabl
+        run: npm install -g @mablhq/mabl-cli
+      - name: mabl end-to-end test - TEST
+        run: mabl deployments create --api-key ${{ secrets.MABLAPIKEY }} --application-id ${{ secrets.MABLAPPID }} --environment-id ${{ secrets.MABLENVTEST }} --labels MIMIR --await-completion


### PR DESCRIPTION
We want to run Mabl tests on the published versions. These changes has been done to achive this:

* Add job to run Mabl test
* Move XP deploy URLs to github secrets
* Force Github Action to react to push on this branch, to allow for testing
* Fix typo in job name (an error from a previous PR)
* Update test cert and key to allign the naming convention for the Github action secrets