### PR TITLE
Mimir 1227 updates and manual deploy workflow

### DIFF
--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -1,25 +1,22 @@
 name: 'Manual deploy to PROD'
 # Action that will download previously created artifact and deploy it to the production environment
 on:
-  push:
-    branches:
-      - 'MIMIR-1227_updates-and-manual-deploy'
-
-  # workflow_dispatch:
-  #  # We need the Github Action Run number to select which artifact to download
-  #   inputs:
-  #     gh_run_number:
-  #       description: 'The Github Action run number to deploy'
-  #       required: true
+  workflow_dispatch:
+   # We need the Github Action Run number to select which artifact to download
+    inputs:
+      gh_run_number:
+        description: 'The Github Action run number to deploy'
+        required: true
 
 jobs:
   deploy-artifact:
     name: 'Deploy artifact'
     runs-on: ubuntu-latest
     steps:
-      - name: download artifact
-        uses: actions/download-artifact@v3
+      - name: Download workflow artifact
+        uses: dawidd6/action-download-artifact@v2.23.0
         with:
-          name: mimir-test-36
+          workflow: deploy_to_test.yaml
+          run_number: ${{ github.event.input.gh_run_number }}
       - name: display downloads
         run: ls -R

--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -5,7 +5,7 @@ on:
    # We need the Github Action Run number to select which artifact to download
     inputs:
       gh_run_number:
-        description: 'The Github Action run number to deploy'
+        description: 'The Github Action run number from the "Deploy to QA" workflow to deploy'
         required: true
 
 jobs:
@@ -16,7 +16,51 @@ jobs:
       - name: Download workflow artifact
         uses: dawidd6/action-download-artifact@v2.23.0
         with:
-          workflow: deploy_to_test.yaml
+          workflow: deploy_to_qa.yaml
           run_number: ${{ github.event.input.gh_run_number }}
       - name: display downloads
         run: ls -R
+      - name: Send result message to Slack
+        id: slack_message
+        if: ${{ always() }}
+        uses: slackapi/slack-github-action@v1
+        with:
+          # Using Github block kit (https://api.slack.com/reference/block-kit/blocks) to configure the Slack message, see https://docs.github.com/en/actions/learn-github-actions/contexts
+          # for more information about context variables
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                      "alt_text" : "Github logo"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Run by: *${{ github.actor }}* on: *${{ github.ref_name }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Deploy of build ${{ github.event.input.gh_run_number }} is a *${{ job.status }}*, well done!\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow output>""
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      

--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -1,12 +1,16 @@
 name: 'Manual deploy to PROD'
 # Action that will download previously created artifact and deploy it to the production environment
 on:
-  workflow_dispatch:
-   # We need the Github Action Run number to select which artifact to download
-    inputs:
-      gh_run_number:
-        description: 'The Github Action run number to deploy'
-        required: true
+  push:
+    branches:
+      - 'MIMIR-1227_updates-and-manual-deploy'
+
+  # workflow_dispatch:
+  #  # We need the Github Action Run number to select which artifact to download
+  #   inputs:
+  #     gh_run_number:
+  #       description: 'The Github Action run number to deploy'
+  #       required: true
 
 jobs:
   deploy-artifact:

--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -1,21 +1,21 @@
-name: Manual deploy to PROD
+name: 'Manual deploy to PROD'
 # Action that will download previously created artifact and deploy it to the production environment
-
 on:
   workflow_dispatch:
    # We need the Github Action Run number to select which artifact to download
     inputs:
       gh_run_number:
-        description: "The Github Action run number to deploy"
+        description: 'The Github Action run number to deploy'
         required: true
 
 jobs:
   deploy-artifact:
-    name: "Deploy artifact"
+    name: 'Deploy artifact'
+    runs-on: ubuntu-latest
     steps:
-      - id: download_artifact
+      - name: download artifact
         uses: actions/download-artifact@v3
         with:
           name: mimir-test-${{ github.event.inputs.gh_run_number }}
-      - id: display_downloaded_artifac
+      - name: display downloads
         run: ls -R

--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -1,16 +1,12 @@
 name: 'Manual deploy to PROD'
 # Action that will download previously created artifact and deploy it to the production environment
 on:
-  push:
-    branches:
-      - 'MIMIR-1227_updates-and-manual-deploy'
-
-  # workflow_dispatch:
-  #  # We need the Github Action Run number to select which artifact to download
-  #   inputs:
-  #     gh_run_number:
-  #       description: 'The Github Action run number to deploy'
-  #       required: true
+  workflow_dispatch:
+   # We need the Github Action Run number to select which artifact to download
+    inputs:
+      gh_run_number:
+        description: 'The Github Action run number to deploy'
+        required: true
 
 jobs:
   deploy-artifact:

--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -1,12 +1,16 @@
 name: 'Manual deploy to PROD'
 # Action that will download previously created artifact and deploy it to the production environment
 on:
-  workflow_dispatch:
-   # We need the Github Action Run number to select which artifact to download
-    inputs:
-      gh_run_number:
-        description: 'The Github Action run number to deploy'
-        required: true
+  push:
+    branches:
+      - 'MIMIR-1227_updates-and-manual-deploy'
+
+  # workflow_dispatch:
+  #  # We need the Github Action Run number to select which artifact to download
+  #   inputs:
+  #     gh_run_number:
+  #       description: 'The Github Action run number to deploy'
+  #       required: true
 
 jobs:
   deploy-artifact:
@@ -16,6 +20,6 @@ jobs:
       - name: download artifact
         uses: actions/download-artifact@v3
         with:
-          name: mimir-test-${{ github.event.inputs.gh_run_number }}
+          name: mimir-test-35
       - name: display downloads
         run: ls -R

--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -20,6 +20,6 @@ jobs:
       - name: download artifact
         uses: actions/download-artifact@v3
         with:
-          name: mimir-test-35
+          name: mimir-test-36
       - name: display downloads
         run: ls -R

--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -1,0 +1,21 @@
+name: Manual deploy to PROD
+# Action that will download previously created artifact and deploy it to the production environment
+
+on:
+  workflow_dispatch:
+   # We need the Github Action Run number to select which artifact to download
+    inputs:
+      gh_run_number:
+        description: "The Github Action run number to deploy"
+        required: true
+
+jobs:
+  deploy-artifact:
+    name: "Deploy artifact"
+    steps:
+      - id: download_artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: mimir-test-${{ github.event.inputs.gh_run_number }}
+      - id: display_downloaded_artifac
+        run: ls -R

--- a/.github/workflows/deploy_to_qa.yaml
+++ b/.github/workflows/deploy_to_qa.yaml
@@ -22,6 +22,13 @@ jobs:
           client_cert: ${{ secrets.ENONIC_QA_CERT }}
           client_key: ${{ secrets.ENONIC_QA_KEY }}
           app_jar: "./build/libs/*.jar"
+      - name: Upload artifacts
+        id: upload_artifacts
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mimir-qa-${{ github.run_number }}
+          path: "./build/libs/*.jar"
       - name: Send success message to Slack
         id: slack_success
         if: success()

--- a/.github/workflows/deploy_to_test.yaml
+++ b/.github/workflows/deploy_to_test.yaml
@@ -29,7 +29,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v3
         with:
-          name: SSB-XP
+          name: SSB-XP-${{ github.run_number }}
           path: "./build/libs/*.jar"
       - name: Send success message to Slack
         id: slack_success

--- a/.github/workflows/deploy_to_test.yaml
+++ b/.github/workflows/deploy_to_test.yaml
@@ -29,7 +29,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v3
         with:
-          name: SSB-XP-${{ github.run_number }}
+          name: mimir-test-${{ github.run_number }}
           path: "./build/libs/*.jar"
       - name: Send success message to Slack
         id: slack_success

--- a/.github/workflows/deploy_to_test.yaml
+++ b/.github/workflows/deploy_to_test.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - 'mabl-test-from-gha'
+      - 'MIMIR-1227_updates-and-manual-deploy'
   
 jobs:
   deploy_to_test:
@@ -24,6 +24,13 @@ jobs:
           client_cert: ${{ secrets.ENONIC_TEST_CERT }}
           client_key: ${{ secrets.ENONIC_TEST_KEY }}
           app_jar: "./build/libs/*.jar"
+      - name: Upload artifacts
+        id: upload_artifacts
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: SSB-XP
+          path: "./build/libs/*.jar"
       - name: Send success message to Slack
         id: slack_success
         if: success()

--- a/.github/workflows/manual_deploy_to_prod.yaml
+++ b/.github/workflows/manual_deploy_to_prod.yaml
@@ -5,7 +5,7 @@ on:
    # We need the Github Action Run number to select which artifact to download
     inputs:
       gh_run_number:
-        description: 'The Github Action run number from the "Deploy to QA" workflow to deploy'
+        description: 'The Github Action run number to deploy'
         required: true
 
 jobs:
@@ -17,9 +17,19 @@ jobs:
         uses: dawidd6/action-download-artifact@v2.23.0
         with:
           workflow: deploy_to_qa.yaml
-          run_number: ${{ github.event.input.gh_run_number }}
+          run_number: ${{ github.event.inputs.gh_run_number }}
       - name: display downloads
         run: ls -R
+      - id: deploy_app_to_XP
+        uses: 'enonic/action-app-deploy@main'
+        with:
+          # Secrets from Github repository
+          url: ${{ secrets.ENONIC_PROD_URL }}
+          username: ${{ secrets.ENONIC_PROD_USER }}
+          password: ${{ secrets.ENONIC_PROD_PASS }}
+          client_cert: ${{ secrets.ENONIC_PROD_CERT }}
+          client_key: ${{ secrets.ENONIC_PROD_KEY }}
+          app_jar: "*.jar"
       - name: Send result message to Slack
         id: slack_message
         if: ${{ always() }}
@@ -55,7 +65,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Deploy of build ${{ github.event.input.gh_run_number }} is a *${{ job.status }}*, well done!\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow output>""
+                    "text": "Deploy of build ${{ github.event.input.gh_run_number }} is a *${{ job.status }}*, well done!\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow output>"
                   }
                 }
               ]
@@ -63,4 +73,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-      

--- a/.github/workflows/manual_deploy_to_test.yml
+++ b/.github/workflows/manual_deploy_to_test.yml
@@ -30,3 +30,46 @@ jobs:
           client_cert: ${{ secrets.ENONIC_TEST_CERT }}
           client_key: ${{ secrets.ENONIC_TEST_KEY }}
           app_jar: "*.jar"
+      - name: Send result message to Slack
+        id: slack_message
+        if: ${{ always() }}
+        uses: slackapi/slack-github-action@v1
+        with:
+          # Using Github block kit (https://api.slack.com/reference/block-kit/blocks) to configure the Slack message, see https://docs.github.com/en/actions/learn-github-actions/contexts
+          # for more information about context variables
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                      "alt_text" : "Github logo"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "Run by: *${{ github.actor }}* on: *${{ github.ref_name }}*"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Deploy of build ${{ github.event.input.gh_run_number }} is a *${{ job.status }}*, well done!\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow output>""
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MIMIR_UTV }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/manual_deploy_to_test.yml
+++ b/.github/workflows/manual_deploy_to_test.yml
@@ -65,7 +65,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Deploy of build ${{ github.event.input.gh_run_number }} is a *${{ job.status }}*, well done!\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow output>""
+                    "text": "Deploy of build ${{ github.event.input.gh_run_number }} is a *${{ job.status }}*, well done!\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow output>"
                   }
                 }
               ]

--- a/.github/workflows/manual_deploy_to_test.yml
+++ b/.github/workflows/manual_deploy_to_test.yml
@@ -17,6 +17,6 @@ jobs:
         uses: dawidd6/action-download-artifact@v2.23.0
         with:
           workflow: deploy_to_test.yaml
-          run_number: ${{ github.event.input.gh_run_number }}
+          run_number: ${{ github.event.inputs.gh_run_number }}
       - name: display downloads
         run: ls -R

--- a/.github/workflows/manual_deploy_to_test.yml
+++ b/.github/workflows/manual_deploy_to_test.yml
@@ -20,3 +20,13 @@ jobs:
           run_number: ${{ github.event.inputs.gh_run_number }}
       - name: display downloads
         run: ls -R
+      - id: deploy_app_to_XP
+        uses: 'enonic/action-app-deploy@main'
+        with:
+          # Secrets from Github repository
+          url: ${{ secrets.ENONIC_TEST_URL }}
+          username: ${{ secrets.ENONIC_TEST_USER }}
+          password: ${{ secrets.ENONIC_TEST_PASS }}
+          client_cert: ${{ secrets.ENONIC_TEST_CERT }}
+          client_key: ${{ secrets.ENONIC_TEST_KEY }}
+          app_jar: "*.jar"


### PR DESCRIPTION
We want to enable Github actions to replace Drone as the tool for building and deploying new code.

This is made possible with two automatic workflows, one that triggers on creating Pull Request and deploys to the test environment, and one that triggers on merge to the main branch and deploys to the QA environment. Both these workflows will upload the built artifacts when successful.

In addition we have created to workflows that has to be manually triggered, and needs the run number for a previously successful run of one of the two automatic workflows as input. These workflows download the previously built artifacts and deploys them, to the test or production environments respectively.

All workflows report results to a Slack channel.