### PR TITLE
Remove id from cached divider.

### DIFF
--- a/src/main/resources/site/parts/divider/divider.ts
+++ b/src/main/resources/site/parts/divider/divider.ts
@@ -25,12 +25,16 @@ function renderPart(req: XP.Request, config: DividerPartConfig): XP.Response {
   const dividerColor: string = config.dividerColor || 'light'
 
   return fromPartCache(req, `divider${dividerColor}`, () => {
-    return render('Divider', setColor(dividerColor), req, {
+    const result = render('Divider', setColor(dividerColor), req, {
       body: '<section class="xp-part part-divider"></section>',
+      hydrate: false,
       pageContributions: {
         bodyEnd: [scriptAsset('js/divider.js')],
       },
     })
+
+    result.body = result.body.replace(/ id=".*?"/i, '')
+    return result
   })
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,8 @@
     "paths": {
       "/admin/*": ["./src/main/resources/admin/*"],
       "/lib/xp/*": ["./node_modules/@enonic-types/lib-*"],
-      "/lib/*": [ "./node_modules/@item-enonic-types/lib-*" ,"./src/main/resources/lib/*"],
       "/lib/enonic/react4xp": ["./node_modules/@enonic-types/lib-react4xp"],
+      "/lib/*": [ "./node_modules/@item-enonic-types/lib-*" ,"./src/main/resources/lib/*"],
       "/react4xp/*": ["./src/main/resources/react4xp/*"],
       "/services/*": ["./src/main/resources/services/*"],
       "/site/*": [


### PR DESCRIPTION
Since it does not hydrate we can safely remove id.

Alle r4xp parts som trenger hydrering i clienten (de som har funksjonalitet, eventlistener, onclick etc) MÅ ha en unik id for å fungere. Siden divider er statisk kan vi skru av hydrering og fjerne id. 


