### PR TITLE
nn fix( !=='en')

### DIFF
--- a/src/main/resources/assets/js/app/highchart.es6
+++ b/src/main/resources/assets/js/app/highchart.es6
@@ -31,10 +31,9 @@ const EMPTY_CONFIG = {
 
 // HIGHCHART
 export function init() {
-  //Highchart language
-  //if html = 'nb' then accessibilityLang selected, if html = 'en' then default higcharts eng (no accessibiltyLang selected)
+  //Highchart language checker
   const lang = $('html').attr('lang')
-  if (lang === 'nb') {
+  if (lang !== 'en') {
     Highcharts.setOptions(accessibilityLang)
   }
 

--- a/src/main/resources/site/parts/nameSearch/nameSearch.jsx
+++ b/src/main/resources/site/parts/nameSearch/nameSearch.jsx
@@ -271,7 +271,7 @@ function NameSearch(props) {
     const lineColor = '#21383a'
 
     // Highchart language checker
-    if (language === 'nb') {
+    if (language !== 'en') {
       Highcharts.setOptions({
         lang: {
           ...accessibilityLang.lang,


### PR DESCRIPTION
fixes the error - where nynorsk pages still have decimalpoint = ' . ' and where the text is in english 

this will set the default highcharts language to nb / nn and use the default higcharts language when lang === en (witch is english)