### PR TITLE
Fix Thymeleaf Rendering Error by Handling Undefined Variables

### DIFF
--- a/src/main/resources/site/layouts/triple/triple.es6
+++ b/src/main/resources/site/layouts/triple/triple.es6
@@ -1,19 +1,18 @@
 import { render } from '/lib/thymeleaf'
 
 const portal = __non_webpack_require__('/lib/xp/portal')
-
 const view = resolve('triple.html')
 
-exports.get = function (req) {
+exports.get = function () {
   const component = portal.getComponent()
   const { title, hideTitle } = component.config
 
   const model = {
     title,
     hideTitle,
-    leftRegion: component.regions.left,
-    centerRegion: component.regions.center,
-    rightRegion: component.regions.right,
+    leftRegion: component.regions?.left || { components: [] },
+    centerRegion: component.regions?.center || { components: [] },
+    rightRegion: component.regions?.right || { components: [] },
   }
 
   const body = render(view, model)


### PR DESCRIPTION
Resolved the Thymeleaf rendering error: "Exception evaluating OGNL expression: 'centerRegion.components'" (found in "mimir:/site/layouts/triple/triple.html" - line 11, col 12). Implemented a check for null or undefined variables before template parsing. Added a safeguard to assign empty arrays to variables if they are null or undefined, preventing Thymeleaf from throwing errors when a region is empty at render time.