### PR TITLE
Remove unused entry

### DIFF
--- a/src/main/resources/react4xp/_entries/relatedImageBox.jsx
+++ b/src/main/resources/react4xp/_entries/relatedImageBox.jsx
@@ -1,4 +1,0 @@
-import React from 'react'
-import { ImageLink } from '@statisticsnorway/ssb-component-library'
-
-export default (props) => <ImageLink {...props} />


### PR DESCRIPTION
Fjerne ubruk react komponent. Den importere noe som ikke fantes fra komponentbiblioteket som ga warnings i bygg loggene.