### PR TITLE
[MIM-1610] MIM-1610-fixed lacking visual for single point series

### DIFF
--- a/src/main/resources/assets/js/app/highchart.es6
+++ b/src/main/resources/assets/js/app/highchart.es6
@@ -119,20 +119,18 @@ export function init() {
           },
         }
 
-        // Only show plotOption marker on last data element
-        if (canvas.data('type') === 'line') {
-          config.series.forEach(function (series) {
-            const lastIndex = series.data.length - 1
-            series.data.forEach(function (data, index) {
-              series.data[index] = {
-                y: parseFloat(data),
-                marker: {
-                  enabled: index === lastIndex,
-                },
-              }
-            })
-          })
-        }
+        // Only show plotOption marker on last data element / single data point series
+        config.series.forEach((series) => {
+          const isLineSeries = canvas.data('type') === 'line'
+          const nonNullPoints = series.data.filter((data) => data !== null).length
+
+          series.data = series.data.map((data, index) => ({
+            y: parseFloat(data),
+            marker: {
+              enabled: isLineSeries && (nonNullPoints === 1 || index === series.data.length - 1),
+            },
+          }))
+        })
 
         const category = 'Highcharts'
         const action = 'Lastet ned highcharts'

--- a/src/main/resources/assets/js/app/highchart.es6
+++ b/src/main/resources/assets/js/app/highchart.es6
@@ -120,17 +120,18 @@ export function init() {
         }
 
         // Only show plotOption marker on last data element / single data point series
-        config.series.forEach((series) => {
-          const isLineSeries = canvas.data('type') === 'line'
-          const nonNullPoints = series.data.filter((data) => data !== null).length
+        if (canvas.data('type') === 'line') {
+          config.series.forEach((series) => {
+            const nonNullPoints = series.data.filter((data) => data !== null).length
 
-          series.data = series.data.map((data, index) => ({
-            y: parseFloat(data),
-            marker: {
-              enabled: isLineSeries && (nonNullPoints === 1 || index === series.data.length - 1),
-            },
-          }))
-        })
+            series.data = series.data.map((data, index) => ({
+              y: parseFloat(data),
+              marker: {
+                enabled: nonNullPoints === 1 || index === nonNullPoints - 1,
+              },
+            }))
+          })
+        }
 
         const category = 'Highcharts'
         const action = 'Lastet ned highcharts'


### PR DESCRIPTION
I changed the original if statement to also enable markers for series.data that only contain one non-null data point. Now, if a series has only one data point, that point will be marked, and the user will not need to hover over it to see it.

[Link to ticket: MIM-1610](https://statistics-norway.atlassian.net/browse/MIM-1610)