### PR TITLE
[MIM-1707] Wrap most cron jobs in isMaster so no duplicate work is done

### DIFF
--- a/src/main/resources/lib/ssb/cron/cron.ts
+++ b/src/main/resources/lib/ssb/cron/cron.ts
@@ -156,119 +156,6 @@ export function runOnMasterOnly(task: () => void): void {
 export function setupCronJobs(): void {
   run(createUserContext, setupCronJobUser)
 
-  // setup dataquery cron job
-  const dataqueryCron: string =
-    app.config && app.config['ssb.cron.dataquery'] ? app.config['ssb.cron.dataquery'] : '0 15 * * *'
-  schedule({
-    name: 'Data from datasource endpoints',
-    cron: dataqueryCron,
-    callback: () => {
-      libScheduleTestLog('dataqueryCronTest', dataqueryCron)
-      runOnMasterOnly(job)
-    },
-    context: cronContext,
-  })
-  // using config in https://github.com/statisticsnorway/mimir-config/blob/master/prod/mimir.cfg as base
-  libScheduleTest({ name: 'dataqueryCronTest', cron: '03 08 * * *', timeZone: 'Europe/Oslo' }, dataqueryCron)
-
-  // clear calculator parts cache cron
-  const clearCalculatorPartsCacheCron: string =
-    app.config && app.config['ssb.cron.clearCalculatorCache']
-      ? app.config['ssb.cron.clearCalculatorCache']
-      : '15 07 * * *'
-
-  schedule({
-    name: 'Clear calculator parts cache',
-    cron: clearCalculatorPartsCacheCron,
-    callback: () => {
-      libScheduleTestLog('clearCalculatorCronTest', clearCalculatorPartsCacheCron)
-      clearPartFromPartCache('kpiCalculator')
-      clearPartFromPartCache('pifCalculator')
-      clearPartFromPartCache('bkibolCalculator')
-      clearPartFromPartCache('husleieCalculator')
-    },
-    context: cronContext,
-  })
-  libScheduleTest(
-    { name: 'clearCalculatorCronTest', cron: '15 08 * * *', timeZone: 'Europe/Oslo' },
-    clearCalculatorPartsCacheCron
-  )
-
-  // and setup a cron for periodic executions in the future
-  const statregCron: string =
-    app.config && app.config['ssb.cron.statreg'] ? app.config['ssb.cron.statreg'] : '30 14 * * *'
-  schedule({
-    name: 'StatReg Periodic Refresh',
-    cron: statregCron,
-    callback: () => {
-      libScheduleTestLog('statregRefreshCronTest', statregCron)
-      runOnMasterOnly(statRegJob)
-    },
-    context: cronContext,
-  })
-  libScheduleTest({ name: 'statregRefreshCronTest', cron: '05 8 * * *', timeZone: 'Europe/Oslo' }, statregCron)
-
-  // Update repo no.ssb.statistic.variant
-  const updateStatisticRepoCron: string =
-    app.config && app.config['ssb.cron.updateStatisticRepo'] ? app.config['ssb.cron.updateStatisticRepo'] : '0 7 * * *'
-
-  schedule({
-    name: 'Update no.ssb.statistics Repo',
-    cron: updateStatisticRepoCron,
-    callback: () => {
-      libScheduleTestLog('statregUpdateCronTest', updateStatisticRepoCron)
-      runOnMasterOnly(createOrUpdateStatisticsRepo)
-    },
-    context: cronContext,
-  })
-  libScheduleTest(
-    { name: 'statregUpdateCronTest', cron: '0 8 * * *', timeZone: 'Europe/Oslo' },
-    updateStatisticRepoCron
-  )
-
-  const deleteExpiredEventLogCron: string =
-    app.config && app.config['ssb.cron.deleteLogs'] ? app.config['ssb.cron.deleteLogs'] : '45 13 * * *'
-  schedule({
-    name: 'Delete expired event logs for queries',
-    cron: deleteExpiredEventLogCron,
-    callback: () => {
-      libScheduleTestLog('deleteExpireCronTest', deleteExpiredEventLogCron)
-      runOnMasterOnly(deleteExpiredEventLogsForQueries)
-    },
-    context: cronContext,
-  })
-  libScheduleTest(
-    { name: 'deleteExpireCronTest', cron: '20 15 * * *', timeZone: 'Europe/Oslo' },
-    deleteExpiredEventLogCron
-  )
-
-  if (app.config && app.config['ssb.mock.enable'] === 'true') {
-    const updateUnpublishedMockCron: string =
-      app.config && app.config['ssb.cron.updateUnpublishedMock']
-        ? app.config['ssb.cron.updateUnpublishedMock']
-        : '0 04 * * *'
-    schedule({
-      name: 'Update unpublished mock tbml',
-      cron: updateUnpublishedMockCron,
-      callback: () => runOnMasterOnly(updateUnpublishedMockTbml),
-      context: cronContext,
-    })
-  }
-
-  // push news to rss feed
-  const pushRssNewsCron: string =
-    app.config && app.config['ssb.cron.pushRssNews'] ? app.config['ssb.cron.pushRssNews'] : '02 06 * * *'
-  schedule({
-    name: 'Push RSS news',
-    cron: pushRssNewsCron,
-    callback: () => {
-      libScheduleTestLog('pushRssNewsCronTest', pushRssNewsCron)
-      runOnMasterOnly(pushRssNewsJob)
-    },
-    context: cronContext,
-  })
-  libScheduleTest({ name: 'pushRssNewsCronTest', cron: '01 08 * * *', timeZone: 'Europe/Oslo' }, pushRssNewsCron)
-
   // clear specific cache once an hour
   const clearCacheCron: string =
     app.config && app.config['ssb.cron.clearCacheCron'] ? app.config['ssb.cron.clearCacheCron'] : '01 * * * *'
@@ -291,38 +178,151 @@ export function setupCronJobs(): void {
     context: cronContext,
   })
 
-  // Update SDDS tables
-  const updateSDDSTablesCron: string =
-    app.config && app.config['ssb.cron.updateSDDSTables'] ? app.config['ssb.cron.updateSDDSTables'] : '01 09 * * *'
+  // clear calculator parts cache cron
+  const clearCalculatorPartsCacheCron: string =
+    app.config && app.config['ssb.cron.clearCalculatorCache']
+      ? app.config['ssb.cron.clearCalculatorCache']
+      : '15 07 * * *'
+
   schedule({
-    name: 'Update SDDS tables',
-    cron: updateSDDSTablesCron,
+    name: 'Clear calculator parts cache',
+    cron: clearCalculatorPartsCacheCron,
     callback: () => {
-      libScheduleTestLog('updateSDDSCronTest', updateSDDSTablesCron)
-      runOnMasterOnly(updateSDDSTables)
+      libScheduleTestLog('clearCalculatorCronTest', clearCalculatorPartsCacheCron)
+      clearPartFromPartCache('kpiCalculator')
+      clearPartFromPartCache('pifCalculator')
+      clearPartFromPartCache('bkibolCalculator')
+      clearPartFromPartCache('husleieCalculator')
     },
     context: cronContext,
   })
-  libScheduleTest({ name: 'updateSDDSCronTest', cron: '01 09 * * *', timeZone: 'Europe/Oslo' }, updateSDDSTablesCron)
 
-  const datasetPublishCron: string =
-    app.config && app.config['ssb.cron.publishDataset'] ? app.config['ssb.cron.publishDataset'] : '50 05 * * *'
-
-  log.info('Run old datasetPublishCron cron-library')
-  // publish dataset cron job
-  schedule({
-    name: 'Dataset publish',
-    cron: datasetPublishCron,
-    callback: () => {
-      libScheduleTestLog('datasetPublishCronTest', datasetPublishCron)
-      runOnMasterOnly(publishDataset)
-    },
-    context: cronContext,
-  })
-  libScheduleTest({ name: 'datasetPublishCronTest', cron: '50 07 * * *', timeZone: 'Europe/Oslo' }, datasetPublishCron)
-
-  // Task
   if (isMaster()) {
+    // setup dataquery cron job
+    const dataqueryCron: string =
+      app.config && app.config['ssb.cron.dataquery'] ? app.config['ssb.cron.dataquery'] : '0 15 * * *'
+    schedule({
+      name: 'Data from datasource endpoints',
+      cron: dataqueryCron,
+      callback: () => {
+        libScheduleTestLog('dataqueryCronTest', dataqueryCron)
+        job()
+      },
+      context: cronContext,
+    })
+    // using config in https://github.com/statisticsnorway/mimir-config/blob/master/prod/mimir.cfg as base
+    libScheduleTest({ name: 'dataqueryCronTest', cron: '03 08 * * *', timeZone: 'Europe/Oslo' }, dataqueryCron)
+
+    // and setup a cron for periodic executions in the future
+    const statregCron: string =
+      app.config && app.config['ssb.cron.statreg'] ? app.config['ssb.cron.statreg'] : '30 14 * * *'
+    schedule({
+      name: 'StatReg Periodic Refresh',
+      cron: statregCron,
+      callback: () => {
+        libScheduleTestLog('statregRefreshCronTest', statregCron)
+        statRegJob()
+      },
+      context: cronContext,
+    })
+    libScheduleTest({ name: 'statregRefreshCronTest', cron: '05 8 * * *', timeZone: 'Europe/Oslo' }, statregCron)
+
+    // Update repo no.ssb.statistic.variant
+    const updateStatisticRepoCron: string =
+      app.config && app.config['ssb.cron.updateStatisticRepo']
+        ? app.config['ssb.cron.updateStatisticRepo']
+        : '0 7 * * *'
+
+    schedule({
+      name: 'Update no.ssb.statistics Repo',
+      cron: updateStatisticRepoCron,
+      callback: () => {
+        libScheduleTestLog('statregUpdateCronTest', updateStatisticRepoCron)
+        createOrUpdateStatisticsRepo()
+      },
+      context: cronContext,
+    })
+    libScheduleTest(
+      { name: 'statregUpdateCronTest', cron: '0 8 * * *', timeZone: 'Europe/Oslo' },
+      updateStatisticRepoCron
+    )
+
+    const deleteExpiredEventLogCron: string =
+      app.config && app.config['ssb.cron.deleteLogs'] ? app.config['ssb.cron.deleteLogs'] : '45 13 * * *'
+    schedule({
+      name: 'Delete expired event logs for queries',
+      cron: deleteExpiredEventLogCron,
+      callback: () => {
+        libScheduleTestLog('deleteExpireCronTest', deleteExpiredEventLogCron)
+        deleteExpiredEventLogsForQueries()
+      },
+      context: cronContext,
+    })
+    libScheduleTest(
+      { name: 'deleteExpireCronTest', cron: '20 15 * * *', timeZone: 'Europe/Oslo' },
+      deleteExpiredEventLogCron
+    )
+
+    if (app.config && app.config['ssb.mock.enable'] === 'true') {
+      const updateUnpublishedMockCron: string =
+        app.config && app.config['ssb.cron.updateUnpublishedMock']
+          ? app.config['ssb.cron.updateUnpublishedMock']
+          : '0 04 * * *'
+      schedule({
+        name: 'Update unpublished mock tbml',
+        cron: updateUnpublishedMockCron,
+        callback: () => updateUnpublishedMockTbml(),
+        context: cronContext,
+      })
+    }
+
+    // push news to rss feed
+    const pushRssNewsCron: string =
+      app.config && app.config['ssb.cron.pushRssNews'] ? app.config['ssb.cron.pushRssNews'] : '02 06 * * *'
+    schedule({
+      name: 'Push RSS news',
+      cron: pushRssNewsCron,
+      callback: () => {
+        libScheduleTestLog('pushRssNewsCronTest', pushRssNewsCron)
+        pushRssNewsJob()
+      },
+      context: cronContext,
+    })
+    libScheduleTest({ name: 'pushRssNewsCronTest', cron: '01 08 * * *', timeZone: 'Europe/Oslo' }, pushRssNewsCron)
+
+    // Update SDDS tables
+    const updateSDDSTablesCron: string =
+      app.config && app.config['ssb.cron.updateSDDSTables'] ? app.config['ssb.cron.updateSDDSTables'] : '01 09 * * *'
+    schedule({
+      name: 'Update SDDS tables',
+      cron: updateSDDSTablesCron,
+      callback: () => {
+        libScheduleTestLog('updateSDDSCronTest', updateSDDSTablesCron)
+        updateSDDSTables()
+      },
+      context: cronContext,
+    })
+    libScheduleTest({ name: 'updateSDDSCronTest', cron: '01 09 * * *', timeZone: 'Europe/Oslo' }, updateSDDSTablesCron)
+
+    const datasetPublishCron: string =
+      app.config && app.config['ssb.cron.publishDataset'] ? app.config['ssb.cron.publishDataset'] : '50 05 * * *'
+
+    log.info('Run old datasetPublishCron cron-library')
+    // publish dataset cron job
+    schedule({
+      name: 'Dataset publish',
+      cron: datasetPublishCron,
+      callback: () => {
+        libScheduleTestLog('datasetPublishCronTest', datasetPublishCron)
+        publishDataset()
+      },
+      context: cronContext,
+    })
+    libScheduleTest(
+      { name: 'datasetPublishCronTest', cron: '50 07 * * *', timeZone: 'Europe/Oslo' },
+      datasetPublishCron
+    )
+
     const timezone: string =
       app.config && app.config['ssb.cron.timezone'] ? app.config['ssb.cron.timezone'] : 'Europe/Oslo'
 


### PR DESCRIPTION
Flyttet de fleste cron jobbene inni isMaster istedenfor å kjøre runOnlyOnMaster på hver callback. De som skal kjøre på hver node (clear cache) er flytta uttafor den. 

Det at libScheduleTest slettet også lagde en schedule gjorde at det ble mye kluss og asynkhet når dette skjedde på alle noder. 

[Link to ticket: MIM-1707](https://statistics-norway.atlassian.net/browse/MIM-1707)