### PR TITLE
Hotfix fragment not working

### DIFF
--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -130,7 +130,7 @@ export function get(req: XP.Request): XP.Response {
   }
   const language: Language = getLanguage(page) as Language
   const menuCacheLanguage: string = language.code === 'en' ? 'en' : 'nb'
-  const hideHeader = isEnabled('hide-header-in-qa', false, 'ssb') ? pageConfig.hideHeader : false
+  const hideHeader = isEnabled('hide-header-in-qa', false, 'ssb') ? pageConfig?.hideHeader : false
   let header
   if (!hideHeader) {
     const headerContent: MenuContent | unknown = fromMenuCache(req, `header_${menuCacheLanguage}`, () => {

--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -130,7 +130,7 @@ export function get(req: XP.Request): XP.Response {
   }
   const language: Language = getLanguage(page) as Language
   const menuCacheLanguage: string = language.code === 'en' ? 'en' : 'nb'
-  const hideHeader = pageConfig.hideHeader && isEnabled('hide-header-in-qa', true, 'ssb')
+  const hideHeader = isEnabled('hide-header-in-qa', false, 'ssb') ? pageConfig.hideHeader : false
   let header
   if (!hideHeader) {
     const headerContent: MenuContent | unknown = fromMenuCache(req, `header_${menuCacheLanguage}`, () => {


### PR DESCRIPTION
Hotfix to production, needed to use fragments in XP

Need to do more explicit test, fails if hideHeader
is undefined

Logical conjunction tries to evaluate possibly undefined key hideHeader
Using ternary operator to test if feature flag is enabled first.