### PR TITLE
[MIM-1743] Refactoring upcoming publications removing unnecessary filter and sorting

### DIFF
--- a/src/main/resources/services/upcomingReleases/upcomingReleases.ts
+++ b/src/main/resources/services/upcomingReleases/upcomingReleases.ts
@@ -8,7 +8,7 @@ import {
   groupStatisticsByYearMonthAndDay,
   prepareRelease,
   filterOnComingReleases,
-  getUpcomingReleases,
+  getAllReleases,
 } from '/lib/ssb/utils/variantUtils'
 
 import { getAllStatisticsFromRepo } from '../../lib/ssb/statreg/statistics'
@@ -16,14 +16,14 @@ import { getAllStatisticsFromRepo } from '../../lib/ssb/statreg/statistics'
 export const get = (req: XP.Request): XP.Response => {
   // Get statistics
   const statistics: Array<StatisticInListing> = getAllStatisticsFromRepo()
-  const upComingReleases: Array<Release> = getUpcomingReleases(statistics)
+  const allReleases: Array<Release> = getAllReleases(statistics)
   const count: number = req.params.count ? parseInt(req.params.count) : 2
   const showAll = !!(req.params.showAll && req.params.showAll === 'true')
 
-  const language: string = req.params.language ? req.params.language : 'nb'
-  const numberOfDays: number = showAll ? getDaysToLatestRelease(upComingReleases) : count
-  // All statistics published today, and fill up with previous releases.
-  const releasesFiltered: Array<Release> = filterOnComingReleases(upComingReleases, numberOfDays, req.params.start)
+  const language = req.params.language ? req.params.language : 'nb'
+  const numberOfDays = showAll ? undefined : count
+  // All statistics from today and a number of days
+  const releasesFiltered: Array<Release> = filterOnComingReleases(allReleases, numberOfDays, req.params.start)
 
   // Choose the right variant and prepare the date in a way it works with the groupBy function
   const releasesPrepped: Array<PreparedStatistics> = releasesFiltered.map((release: Release) =>
@@ -45,13 +45,4 @@ export const get = (req: XP.Request): XP.Response => {
       count,
     },
   }
-}
-
-function getDaysToLatestRelease(upComingReleases: Array<Release>): number {
-  const lastUpcomingRelease: Release = upComingReleases[upComingReleases.length - 1]
-  const today: Date = new Date()
-  const releaseDate: Date = new Date(lastUpcomingRelease.publishTime)
-  const diff: number = Math.abs(today.getTime() - releaseDate.getTime())
-  const diffDays: number = Math.ceil(diff / (1000 * 3600 * 24))
-  return diffDays
 }

--- a/src/main/resources/site/parts/upcomingReleases/upcomingReleases.ts
+++ b/src/main/resources/site/parts/upcomingReleases/upcomingReleases.ts
@@ -12,7 +12,7 @@ import {
   groupStatisticsByYearMonthAndDay,
   prepareRelease,
   filterOnComingReleases,
-  getUpcomingReleases,
+  getAllReleases,
 } from '/lib/ssb/utils/variantUtils'
 import { type StatisticInListing } from '/lib/ssb/dashboard/statreg/types'
 import { render } from '/lib/enonic/react4xp'
@@ -54,10 +54,10 @@ function renderPart(req: XP.Request) {
   const groupedWithMonthNames: Array<YearReleases> = fromPartCache(req, `${content._id}-upcomingReleases`, () => {
     // Get statistics
     const statistics: Array<StatisticInListing> = getAllStatisticsFromRepo()
-    const upComingReleases: Array<Release> = getUpcomingReleases(statistics)
+    const allReleases: Array<Release> = getAllReleases(statistics)
 
-    // All statistics published today, and fill up with previous releases.
-    const releasesFiltered: Array<Release> = filterOnComingReleases(upComingReleases, count)
+    // All statistics from today and a number of days
+    const releasesFiltered: Array<Release> = filterOnComingReleases(allReleases, count)
 
     // Choose the right variant and prepare the date in a way it works with the groupBy function
     const releasesPrepped: Array<PreparedStatistics> = releasesFiltered.map((release: Release) =>
@@ -67,9 +67,6 @@ function renderPart(req: XP.Request) {
     // group by year, then month, then day
     const groupedByYearMonthAndDay: GroupedBy<GroupedBy<GroupedBy<PreparedStatistics>>> =
       groupStatisticsByYearMonthAndDay(releasesPrepped)
-
-    // iterate and format month names
-    // const groupedWithMonthNames: Array<YearReleases> = addMonthNames(groupedByYearMonthAndDay, currentLanguage)
 
     return addMonthNames(groupedByYearMonthAndDay, currentLanguage)
   })
@@ -87,9 +84,9 @@ function renderPart(req: XP.Request) {
     const mainSubject: string = mainSubjectItem ? mainSubjectItem.title : ''
     const contentType: string = r.data.contentType
       ? localize({
-          key: `contentType.${r.data.contentType}`,
-          locale: currentLanguage,
-        })
+        key: `contentType.${r.data.contentType}`,
+        locale: currentLanguage,
+      })
       : ''
 
     return {
@@ -111,8 +108,8 @@ function renderPart(req: XP.Request) {
     releases: groupedWithMonthNames,
     preface: component.config.preface
       ? processHtml({
-          value: component.config.preface,
-        })
+        value: component.config.preface,
+      })
       : undefined,
     language: currentLanguage,
     count,


### PR DESCRIPTION
* All publications are sorted in react-component. I have therefore removed all sorting until then
* Improved filter to only filter releases once (instead of filter all release for each day, potentially 700 instead of 1)
* Only filter by start date once (before it first filtered from now, and then filtered from a given start date)

[Link to ticket: MIM-1743](https://statistics-norway.atlassian.net/browse/MIM-1743)