### PR TITLE
[MIM-1787] Fix search in 404 page. Cant hydrate so use good ol html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@item-enonic-types/lib-thymeleaf": "~2.1.0",
         "@item-enonic-types/lib-time": "~1.0.3",
         "@reduxjs/toolkit": "~1.9.7",
-        "@statisticsnorway/ssb-component-library": "~2.0.96",
+        "@statisticsnorway/ssb-component-library": "~2.0.97",
         "@types/ramda": "~0.29.9",
         "@types/react": "~18.2.47",
         "@types/uuid": "~9.0.7",
@@ -4213,9 +4213,9 @@
       }
     },
     "node_modules/@statisticsnorway/ssb-component-library": {
-      "version": "2.0.96",
-      "resolved": "https://registry.npmjs.org/@statisticsnorway/ssb-component-library/-/ssb-component-library-2.0.96.tgz",
-      "integrity": "sha512-d9UHc2Kb9/FcsQWj4nBPjYw5VyoGEb/8YXul8+ITC30rngLQtmZDN6Dp59i22xZLGoQzoTLDi+y7WMo8Esmt3w==",
+      "version": "2.0.97",
+      "resolved": "https://registry.npmjs.org/@statisticsnorway/ssb-component-library/-/ssb-component-library-2.0.97.tgz",
+      "integrity": "sha512-WR8ghyn14p60YAVsMg+IRJ4b1vj8TgmqYTVydJfpv+/Y/NqUk7TLWppLAiPOcjalbrPangFC99Cye5FqYfG79g==",
       "dev": true,
       "dependencies": {
         "prismjs": "^1.29.0",
@@ -21921,9 +21921,9 @@
       }
     },
     "@statisticsnorway/ssb-component-library": {
-      "version": "2.0.96",
-      "resolved": "https://registry.npmjs.org/@statisticsnorway/ssb-component-library/-/ssb-component-library-2.0.96.tgz",
-      "integrity": "sha512-d9UHc2Kb9/FcsQWj4nBPjYw5VyoGEb/8YXul8+ITC30rngLQtmZDN6Dp59i22xZLGoQzoTLDi+y7WMo8Esmt3w==",
+      "version": "2.0.97",
+      "resolved": "https://registry.npmjs.org/@statisticsnorway/ssb-component-library/-/ssb-component-library-2.0.97.tgz",
+      "integrity": "sha512-WR8ghyn14p60YAVsMg+IRJ4b1vj8TgmqYTVydJfpv+/Y/NqUk7TLWppLAiPOcjalbrPangFC99Cye5FqYfG79g==",
       "dev": true,
       "requires": {
         "prismjs": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@item-enonic-types/lib-thymeleaf": "~2.1.0",
     "@item-enonic-types/lib-time": "~1.0.3",
     "@reduxjs/toolkit": "~1.9.7",
-    "@statisticsnorway/ssb-component-library": "~2.0.96",
+    "@statisticsnorway/ssb-component-library": "~2.0.97",
     "@types/ramda": "~0.29.9",
     "@types/react": "~18.2.47",
     "@types/uuid": "~9.0.7",

--- a/src/main/resources/react4xp/_entries/Search.jsx
+++ b/src/main/resources/react4xp/_entries/Search.jsx
@@ -3,22 +3,19 @@ import { Input } from '@statisticsnorway/ssb-component-library'
 import PropTypes from 'prop-types'
 
 const Search = (props) => {
-  const handleSubmit = (value) => {
-    window.location = `${props.searchResultPageUrl}?sok=${value}`
-  }
-
+  // No pageContributions in error mode, so can't hydrate React components. Thus we go for a simple form.
   return (
-    <React.Fragment>
+    <form action={props.searchResultPageUrl} method='get'>
       <Input
         id='search_ssb'
+        name='sok'
         ariaLabel={props.searchText}
         searchField
-        submitCallback={handleSubmit}
         placeholder={props.searchText}
         ariaLabelSearchButton={props.searchText}
         className={props.className}
       />
-    </React.Fragment>
+    </form>
   )
 }
 
@@ -28,4 +25,4 @@ Search.propTypes = {
   searchResultPageUrl: PropTypes.string,
 }
 
-export default Search
+export default (props) => <Search {...props} />


### PR DESCRIPTION
404 siden skal kanskje byttes ut i fremtiden, men dette fisker ivertfall søket for nå.
Error sider støtter ikke pageContributions i render response, som er noe React4xp trenger for å hydrere siden. Dette gjør at vi ikke kan bruke event listeners o.l. via react. 

[Link to ticket: MIM-1787](https://statistics-norway.atlassian.net/browse/MIM-1787)