### PR TITLE
Removed engines section i package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,10 +159,6 @@
       "@babel/preset-typescript"
     ]
   },
-  "engines": {
-    "node": ">= 16.1.0",
-    "npm": ">= 6.14.8"
-  },
   "dependencies": {
     "bootstrap": "~5.3.2",
     "core-js": "~3.35.1",


### PR DESCRIPTION
This section is only relevant to tell consumers of the npm package what engines your package depends on. Since we don't release any npm it is neither updated by us or relevant to any consumers. Hence removing it.