### PR TITLE
[MIM-1732] added setting for top legend on highcharts

### DIFF
--- a/src/main/resources/lib/ssb/parts/highcharts/graph/config.ts
+++ b/src/main/resources/lib/ssb/parts/highcharts/graph/config.ts
@@ -56,7 +56,6 @@ export const createDefaultConfig = (highchartData, displayName, language) => ({
     spacingRight: 10,
     spacingLeft: 0,
     spacingBottom: 18,
-    // TODO: Med bar-chart kolliderer legend og y-akse-label
     spacingTop: highchartData.legendAlign === 'top' ? 18 : 0,
     marginTop: highchartData.legendAlign === 'top' ? null : 50,
   },

--- a/src/main/resources/lib/ssb/parts/highcharts/graph/config.ts
+++ b/src/main/resources/lib/ssb/parts/highcharts/graph/config.ts
@@ -46,16 +46,19 @@ export const createDefaultConfig = (highchartData, displayName, language) => ({
   chart: {
     height: highchartData.heightAspectRatio > 0 ? `${highchartData.heightAspectRatio}%` : null,
     plotBorderColor: '#e6e6e6',
-    spacingBottom: 18,
     plotBorderWidth: 0,
     style: {
       fontFamily: '"Open Sans Regular", "Arial", "DejaVu Sans", sans-serif',
       fontSize: '14px',
     },
     type: 'bar',
-    spacing: [0, 10, 0, 0],
     zoomType: highchartData.zoomType,
-    marginTop: 50,
+    spacingRight: 10,
+    spacingLeft: 0,
+    spacingBottom: 18,
+    // TODO: Med bar-chart kolliderer legend og y-akse-label
+    spacingTop: highchartData.legendAlign === 'top' ? 18 : 0,
+    marginTop: highchartData.legendAlign === 'top' ? null : 50,
   },
   // SSB color palette:
   colors: [

--- a/src/main/resources/lib/ssb/parts/highcharts/graph/config.ts
+++ b/src/main/resources/lib/ssb/parts/highcharts/graph/config.ts
@@ -137,7 +137,7 @@ export const createDefaultConfig = (highchartData, displayName, language) => ({
   legend: {
     enabled: !highchartData.noLegend,
     align: highchartData.legendAlign === 'right' ? 'right' : 'center',
-    verticalAlign: highchartData.legendAlign == 'right' ? 'top' : 'bottom',
+    verticalAlign: highchartData.legendAlign == 'right' || highchartData.legendAlign == 'top' ? 'top' : 'bottom',
     layout: highchartData.legendAlign == 'right' ? 'vertical' : 'horizontal',
     x: highchartData.legendAlign == 'right' ? 10 : 0,
     y: highchartData.legendAlign == 'right' ? 65 : 0,
@@ -148,6 +148,7 @@ export const createDefaultConfig = (highchartData, displayName, language) => ({
       fontSize: '12px',
       fontWeight: 'normal',
     },
+    width: highchartData.legendAlign == 'top' ? '75%' : 'auto',
     useHTML: true,
   },
   plotOptions: {

--- a/src/main/resources/site/content-types/highchart/highchart.xml
+++ b/src/main/resources/site/content-types/highchart/highchart.xml
@@ -112,6 +112,7 @@
           <config>
             <option value="right">Høyrestilt</option>
             <option value="center">Midtstilt, under</option>
+            <option value="top">Midtstilt, over</option>
           </config>
           <default>center</default>
         </input>


### PR DESCRIPTION
Because highcharts legend does not support margin-right, width is set to 75% to avoid most conflicts with download button.

[Link to ticket: MIM-1732](https://statistics-norway.atlassian.net/browse/MIM-1732)