### PR TITLE
[MIM-1884] Graph type per serie for combinedGraph

### DIFF
--- a/src/main/resources/lib/ssb/parts/highcharts/highchartsGraphConfig.ts
+++ b/src/main/resources/lib/ssb/parts/highcharts/highchartsGraphConfig.ts
@@ -47,7 +47,8 @@ export function prepareCombinedGraphConfig(
     combinedGraphContent.displayName,
     combinedGraphContent.language
   )
-  const yAxis = combinedGraphContent.data.graphs?.map((data, index) => {
+
+  const yAxis = combinedGraphContent.data.yAxis?.map((data, index) => {
     const yAxisConfig = {
       title: {
         text: data.yAxisTitle,
@@ -63,12 +64,12 @@ export function prepareCombinedGraphConfig(
   })
 
   const seriesOption = series
-    ? combinedGraphContent.data.graphs?.map((data, index) => {
+    ? combinedGraphContent.data.series?.map((data, index) => {
         return {
           type: data.graphType,
           data: series[index].data,
           name: series[index].name,
-          yAxis: index,
+          yAxis: data.yAxis && Number(data.yAxis) === 2 ? 1 : undefined,
         }
       })
     : []

--- a/src/main/resources/lib/ssb/parts/highcharts/highchartsGraphConfig.ts
+++ b/src/main/resources/lib/ssb/parts/highcharts/highchartsGraphConfig.ts
@@ -52,15 +52,15 @@ export function prepareCombinedGraphConfig(
     const yAxisConfig = {
       title: {
         text: data?.yAxisTitle,
-        offset: data.yAxisOffset ? parseFloat(data.yAxisOffset) : 0,
+        offset: data?.yAxisOffset ? parseFloat(data.yAxisOffset) : 0,
       },
       opposite: index === 1 ? true : undefined,
-      allowDecimals: data.yAxisDecimalPlaces ? Number(data.yAxisDecimalPlaces) > 0 : undefined,
+      allowDecimals: data?.yAxisDecimalPlaces ? Number(data?.yAxisDecimalPlaces) > 0 : undefined,
       labels: {
-        format: `{value:,.${data.yAxisDecimalPlaces || 0}f}`,
+        format: `{value:,.${data?.yAxisDecimalPlaces || 0}f}`,
       },
-      min: data.yAxisMin && !isNaN(parseFloat(data.yAxisMin)) ? parseFloat(data.yAxisMin) : undefined,
-      max: data.yAxisMax && !isNaN(parseFloat(data.yAxisMax)) ? parseFloat(data.yAxisMax) : undefined,
+      min: data?.yAxisMin && !isNaN(parseFloat(data?.yAxisMin)) ? parseFloat(data?.yAxisMin) : undefined,
+      max: data?.yAxisMax && !isNaN(parseFloat(data?.yAxisMax)) ? parseFloat(data?.yAxisMax) : undefined,
     }
     return mergeDeepRight(defaultConfig.yAxis, yAxisConfig)
   })

--- a/src/main/resources/lib/ssb/parts/highcharts/highchartsGraphConfig.ts
+++ b/src/main/resources/lib/ssb/parts/highcharts/highchartsGraphConfig.ts
@@ -1,7 +1,7 @@
 import { Content } from '/lib/xp/content'
 import { type HighchartsGraphConfig } from '/lib/types/highcharts'
 import { type PreliminaryData } from '/lib/types/xmlParser'
-
+import * as util from '/lib/util'
 import { createDefaultConfig } from '/lib/ssb/parts/highcharts/graph/config'
 import { areaConfig } from '/lib/ssb/parts/highcharts/graph/graphAreaConfig'
 import { pieConfig } from '/lib/ssb/parts/highcharts/graph/graphPieConfig'
@@ -48,10 +48,10 @@ export function prepareCombinedGraphConfig(
     combinedGraphContent.language
   )
 
-  const yAxis = combinedGraphContent.data.yAxis?.map((data, index) => {
+  const yAxis = util.data.forceArray(combinedGraphContent.data.yAxis!).map((data, index) => {
     const yAxisConfig = {
       title: {
-        text: data.yAxisTitle,
+        text: data?.yAxisTitle,
         offset: data.yAxisOffset ? parseFloat(data.yAxisOffset) : 0,
       },
       opposite: index === 1 ? true : undefined,
@@ -59,12 +59,14 @@ export function prepareCombinedGraphConfig(
       labels: {
         format: `{value:,.${data.yAxisDecimalPlaces || 0}f}`,
       },
+      min: data.yAxisMin && !isNaN(parseFloat(data.yAxisMin)) ? parseFloat(data.yAxisMin) : undefined,
+      max: data.yAxisMax && !isNaN(parseFloat(data.yAxisMax)) ? parseFloat(data.yAxisMax) : undefined,
     }
     return mergeDeepRight(defaultConfig.yAxis, yAxisConfig)
   })
 
   const seriesOption = series
-    ? combinedGraphContent.data.series?.map((data, index) => {
+    ? util.data.forceArray(combinedGraphContent.data.series!).map((data, index) => {
         return {
           type: data.graphType,
           data: series[index].data,

--- a/src/main/resources/site/content-types/combinedGraph/combinedGraph.xml
+++ b/src/main/resources/site/content-types/combinedGraph/combinedGraph.xml
@@ -32,13 +32,13 @@
         </options>
     </option-set>
 
-    <item-set name="graphs">  
-        <label>Grafer</label>  
-        <occurrences minimum="0" maximum="2"/>  
+    <item-set name="series">  
+        <label>Serier</label>  
+        <occurrences minimum="0" maximum="10"/>  
         <items>
-            <input name="yAxisTitle" type="TextLine">
-                <label>Y-akse, tittel</label>
-                <occurrences minimum="1" maximum="1"/>
+            <input name="serieTitle" type="TextLine">
+              <label>Tittel</label>
+              <occurrences minimum="1" maximum="1"/>
             </input>
             <input name="graphType" type="RadioButton">
                 <label>Graftype</label>
@@ -49,6 +49,36 @@
                     <option value="bar">Liggende stolpe</option>
                     <option value="area">Areal</option>
                 </config>
+            </input>
+            <input name="yAxis" type="RadioButton">
+              <label>Tilhører Y-akse</label>
+              <occurrences minimum="1" maximum="1"/>  
+              <config>
+                <option value="1">1</option>  
+                <option value="2">2</option>
+              </config>
+              <default>1</default>  
+            </input>
+        </items>     
+    </item-set>
+
+    <item-set name="yAxis">  
+        <label>Y-akse</label>  
+        <occurrences minimum="0" maximum="2"/>  
+        <items>
+            <input name="yAxisTitle" type="TextLine">
+                <label>Y-akse, tittel</label>
+                <occurrences minimum="1" maximum="1"/>
+            </input>
+            <input name="yAxisMin" type="TextLine">
+              <label>Y-akse, minste verdi</label>
+              <help-text>Må være et heltall eller desimaltall. La feltet være blankt for automatisk justering. Hvis aksen er unike kategorier, brukes heltall fra 0 og oppover.</help-text>
+              <regexp>^[0-9]*[,.]?[0-9]+$</regexp>
+            </input>
+            <input name="yAxisMax" type="TextLine">
+              <label>Y-akse, største verdi</label>
+              <help-text>Må være et heltall eller desimaltall. La feltet være blankt for automatisk justering. Hvis aksen er unike kategorier, brukes heltall fra 0 og oppover.</help-text>
+              <regexp>^[0-9]*[,.]?[0-9]+$</regexp>
             </input>
             <input name="yAxisDecimalPlaces" type="RadioButton">
                 <label>Vis desimaler på Y-akseverdiene, antall:</label>

--- a/src/main/resources/site/content-types/combinedGraph/combinedGraph.xml
+++ b/src/main/resources/site/content-types/combinedGraph/combinedGraph.xml
@@ -36,10 +36,6 @@
         <label>Serier</label>  
         <occurrences minimum="0" maximum="10"/>  
         <items>
-            <input name="serieTitle" type="TextLine">
-              <label>Tittel</label>
-              <occurrences minimum="1" maximum="1"/>
-            </input>
             <input name="graphType" type="RadioButton">
                 <label>Graftype</label>
                 <occurrences minimum="1" maximum="1"/>


### PR DESCRIPTION

[Link to ticket: MIM-1884](https://statistics-norway.atlassian.net/browse/MIM-1884)



The "Kombinert Graf" content type upgrades:

1. Graph Type Flexibility: Individual graph types can be assigned to each series, suitable for complex visualizations on both single and dual y-axes.

2. Y-Axis Customization: The item-set previously known as graphs is now yAxis, enabling axis-specific configurations including minimum and maximum values for better data scale representation.

3. Series Configuration: A new series item-set supports up to 10 customizable series, each with a designated title, graph type, and y-axis,
