### PR TITLE
Add mimir to env setting i github

### DIFF
--- a/.github/workflows/deploy_to_qa.yaml
+++ b/.github/workflows/deploy_to_qa.yaml
@@ -13,7 +13,7 @@ jobs:
   deploy_to_qa:
     name: 'Deploy to QA'
     runs-on: 'ubuntu-latest'
-    environment: 'QA'
+    environment: 'QA_mimir'
     steps:
       - id: build_app
         uses: enonic/release-tools/build-and-publish@master


### PR DESCRIPTION
In order to catch repo in deployments and automations in jira we need repo name to be reflected in env name for QA