### PR TITLE
Bump axios from 1.6.0 to 1.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "@types/validator": "~13.12.2",
         "@types/zipcelx": "~1.5.2",
         "autoprefixer": "~10.4.16",
-        "axios": "~1.6.0",
+        "axios": "^1.7.7",
         "babel-loader": "~9.2.1",
         "babel-preset-env": "~1.7.0",
         "browser-sync": "^3.0.3",
@@ -7448,12 +7448,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -26925,12 +26925,12 @@
       }
     },
     "axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@types/validator": "~13.12.2",
     "@types/zipcelx": "~1.5.2",
     "autoprefixer": "~10.4.16",
-    "axios": "~1.6.0",
+    "axios": "^1.7.7",
     "babel-loader": "~9.2.1",
     "babel-preset-env": "~1.7.0",
     "browser-sync": "^3.0.3",


### PR DESCRIPTION
- Resolves `Server-side Request Forgery (SSRF) in axios` from Snyk Vulnerability Report. Also mentioned by Dependabot in the Security Alerts: https://github.com/statisticsnorway/mimir/security/dependabot/59

MIM-2078