### PR TITLE
[MIM-2108] Mim-2108-dateModified-datePublished-fix

### DIFF
--- a/src/main/resources/main.es6
+++ b/src/main/resources/main.es6
@@ -64,10 +64,6 @@ try {
           enabled: false,
         },
         {
-          feature: 'pageMap',
-          enabled: false,
-        },
-        {
           feature: 'show-popup-survey',
           enabled: false,
         },

--- a/src/main/resources/site/pages/default/default.html
+++ b/src/main/resources/site/pages/default/default.html
@@ -51,11 +51,6 @@
   </div>
   <script type="application/ld+json" data-th-if="${jsonLd}" th:inline="javascript">[[${jsonLd}]]</script>
 
-  <div data-th-if="${pageMap}" data-th-remove="tag">
-    <!-- PageMap supplies structured data to search engines, for filtering and rich search -->
-    [(${pageMap})]
-  </div>
-
   <div id="popup" data-th-if="${popupBody}"></div>
 
   <!-- Metainfo to make the page searchable -->

--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -231,8 +231,6 @@ export function get(req: XP.Request): XP.Response {
     metaInfo.addMetaInfoSearch && isEnabled('structured-data', false, 'ssb')
       ? prepareStructuredData(metaInfo, page)
       : undefined
-  const pageMap: string | undefined =
-    metaInfo.addMetaInfoSearch && isEnabled('pageMap', false, 'ssb') ? preparePageMap(metaInfo, page) : undefined
 
   const statbankFane: boolean = req.params.xpframe === 'statbank'
   const statBankContent: StatbankFrameData = parseStatbankFrameContent(statbankFane, req, page)
@@ -271,7 +269,6 @@ export function get(req: XP.Request): XP.Response {
     ...metaInfo,
     metaInfoMainSubjects: metaInfo.metaInfoMainSubjects?.join(';'),
     jsonLd,
-    pageMap,
     breadcrumbsReactId: breadcrumbId,
     hideHeader,
     hideBreadcrumb,
@@ -378,50 +375,20 @@ function prepareStructuredData(metaInfo: MetaInfoData, page: DefaultPage): Artic
           }
         })
       : undefined,
+      publisher:{
+        '@type': 'Organization',
+        name: 'Statistisk sentralbyrå',
+        logo: {
+          '@type': 'ImageObject',
+          url: 'https://www.ssb.no/_/asset/mimir:0000018b60c47e20/SSB_logo_black.svg' 
+        }
+      },
     description: metaInfo.metaInfoDescription
       ? metaInfo.metaInfoDescription
       : page.x['com-enonic-app-metafields']?.['meta-data']?.seoDescription || undefined,
     articleSection: metaInfo.metaInfoMainSubjects?.toString(),
     keywords: metaInfo.metaInfoSearchKeywords,
   }
-}
-
-function preparePageMap(metainfo: MetaInfoData, page: DefaultPage): string {
-  const keywords = metainfo.metaInfoSearchKeywords
-    ? `<Attribute name="keywords" value="${metainfo.metaInfoSearchKeywords}"/>`
-    : ''
-  const author = page.data.authorItemSet
-    ? `<Attribute name="author" value="${ensureArray(page.data.authorItemSet)[0].name}"/>`
-    : ''
-  const category = metainfo.metaInfoMainSubjects
-    ? metainfo.metaInfoMainSubjects
-        .map((subject) => {
-          return `<Attribute name="category" value="${subject}"/>`
-        })
-        .join('\n')
-    : ''
-  const contentType = metainfo.metaInfoSearchContentType
-    ? `<Attribute name="contenttype" value="${metainfo.metaInfoSearchContentType}"/>`
-    : ''
-  const description = metainfo.metaInfoDescription
-    ? metainfo.metaInfoDescription
-    : page.x['com-enonic-app-metafields']?.['meta-data']?.seoDescription || ''
-  return `<!--
-    <PageMap>
-      <DataObject type="publication">
-        <Attribute name="description">${description}</Attribute>
-        ${author}
-        <Attribute name="date" value="${
-          page.data.showModifiedDate?.dateOption?.showModifiedTime
-            ? page.data.showModifiedDate.dateOption.modifiedDate
-            : metainfo.metaInfoSearchPublishFrom
-        }"/>
-        ${category}
-        ${contentType}
-        ${keywords}
-      </DataObject>
-    </PageMap>
-  -->`
 }
 
 function parseMetaInfoData(
@@ -737,7 +704,6 @@ interface DefaultModel {
   GTM_TRACKING_ID: string | null
   GTM_AUTH: string | null
   jsonLd: Article | undefined
-  pageMap: string | undefined
   headerBody: string | undefined
   footerBody: string | undefined
   metaInfoMainSubjects: string | undefined

--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -320,19 +320,6 @@ export function get(req: XP.Request): XP.Response {
         body,
         pageContributions,
       } as XP.Response)
-
-
-
-
-  const structuredData = prepareStructuredData(metaInfo, page);
-    log.info(
-      '\x1b[32m%s\x1b[0m',
-      'Structured Data: ' + JSON.stringify(structuredData, null, 2)
-    );
-        
-
-
-
   return {
     body: `<!DOCTYPE html>${bodyWithAlerts.body}`,
     pageContributions: bodyWithAlerts.pageContributions,

--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -320,6 +320,7 @@ export function get(req: XP.Request): XP.Response {
         body,
         pageContributions,
       } as XP.Response)
+  
   return {
     body: `<!DOCTYPE html>${bodyWithAlerts.body}`,
     pageContributions: bodyWithAlerts.pageContributions,

--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -321,6 +321,18 @@ export function get(req: XP.Request): XP.Response {
         pageContributions,
       } as XP.Response)
 
+
+
+
+  const structuredData = prepareStructuredData(metaInfo, page);
+    log.info(
+      '\x1b[32m%s\x1b[0m',
+      'Structured Data: ' + JSON.stringify(structuredData, null, 2)
+    );
+        
+
+
+
   return {
     body: `<!DOCTYPE html>${bodyWithAlerts.body}`,
     pageContributions: bodyWithAlerts.pageContributions,
@@ -365,8 +377,9 @@ function prepareStructuredData(metaInfo: MetaInfoData, page: DefaultPage): Artic
     additionalType: metaInfo.metaInfoSearchContentType,
     headline: metaInfo.metaInfoTitle,
     datePublished: metaInfo.metaInfoSearchPublishFrom,
-    dateModified: page.data.showModifiedDate?.dateOption?.showModifiedTime
-      ? page.data.showModifiedDate.dateOption.modifiedDate
+    dateModified: page.data.showModifiedDate?.dateOption?.modifiedDate
+      ? page.data.showModifiedDate.dateOption.modifiedDate +
+        (page.data.showModifiedDate.dateOption.showModifiedTime ? 'T' + new Date().toISOString().split('T')[1] : '')
       : undefined,
     author: page.data.authorItemSet
       ? ensureArray(page.data.authorItemSet).map((f) => {


### PR DESCRIPTION
![Screenshot 2025-01-13 at 14 08 00](https://github.com/user-attachments/assets/2dc174c6-2e31-49f1-aa3f-e0e7f19a81aa)

This is an image of the what the Schema of an article looks like in this PR

- dateModified works
- publisher has been added 
- pageMap functionality has been removed from default.ts (as no longer being used)