### PR TITLE
[MIM-2108] MIM-2108-dateModified-schema-fix

### DIFF
--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -363,9 +363,7 @@ function prepareStructuredData(metaInfo: MetaInfoData, page: DefaultPage): Artic
     headline: metaInfo.metaInfoTitle,
     datePublished: metaInfo.metaInfoSearchPublishFrom,
     dateModified: page.data.showModifiedDate?.dateOption?.modifiedDate
-      ? `${page.data.showModifiedDate.dateOption.modifiedDate}${
-          page.data.showModifiedDate.dateOption.showModifiedTime ? `:00` : ''
-        }Z`
+      ? new Date(page.data.showModifiedDate.dateOption.modifiedDate).toISOString()
       : undefined,
     author: page.data.authorItemSet
       ? ensureArray(page.data.authorItemSet).map((f) => {

--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -363,8 +363,9 @@ function prepareStructuredData(metaInfo: MetaInfoData, page: DefaultPage): Artic
     headline: metaInfo.metaInfoTitle,
     datePublished: metaInfo.metaInfoSearchPublishFrom,
     dateModified: page.data.showModifiedDate?.dateOption?.modifiedDate
-      ? page.data.showModifiedDate.dateOption.modifiedDate +
-        (page.data.showModifiedDate.dateOption.showModifiedTime ? 'T' + new Date().toISOString().split('T')[1] : '')
+      ? `${page.data.showModifiedDate.dateOption.modifiedDate}${
+          page.data.showModifiedDate.dateOption.showModifiedTime ? `:00` : ''
+        }Z`
       : undefined,
     author: page.data.authorItemSet
       ? ensureArray(page.data.authorItemSet).map((f) => {
@@ -375,14 +376,14 @@ function prepareStructuredData(metaInfo: MetaInfoData, page: DefaultPage): Artic
           }
         })
       : undefined,
-      publisher:{
-        '@type': 'Organization',
-        name: 'Statistisk sentralbyrå',
-        logo: {
-          '@type': 'ImageObject',
-          url: 'https://www.ssb.no/_/asset/mimir:0000018b60c47e20/SSB_logo_black.svg' 
-        }
+    publisher: {
+      '@type': 'Organization',
+      name: 'Statistisk sentralbyrå',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://www.ssb.no/_/asset/mimir:0000018b60c47e20/SSB_logo_black.svg',
       },
+    },
     description: metaInfo.metaInfoDescription
       ? metaInfo.metaInfoDescription
       : page.x['com-enonic-app-metafields']?.['meta-data']?.seoDescription || undefined,


### PR DESCRIPTION
<img width="829" alt="Screenshot 2025-01-17 at 10 22 09" src="https://github.com/user-attachments/assets/7a5e74b4-7405-4cef-bddd-8c37a3847a17" />

Endringene gir nå riktig Schema-resultat, der det alltid legges til 00 for sekunder og Z for UTC-tidssone, likt datePublished