### PR TITLE
[MIM-2157] Mim 2157 bpi calculator adjustments

### DIFF
--- a/src/main/resources/lib/ssb/utils/calculatorUtils.ts
+++ b/src/main/resources/lib/ssb/utils/calculatorUtils.ts
@@ -101,6 +101,14 @@ export function lastPeriodKpi(kpiDataMonth: Dataset | null): CalculatorPeriod {
   }
 }
 
+export function isStartIndexValid(startIndex: number | null) {
+  return startIndex !== null && startIndex !== 0
+}
+
+export function isEndIndexValid(endIndex: number | null) {
+  return endIndex !== null && endIndex !== 0
+}
+
 export function isChronological(startYear: string, startMonth: string, endYear: string, endMonth: string): boolean {
   if (parseInt(startYear) < parseInt(endYear)) return true
   if (parseInt(endYear) < parseInt(startYear)) return false

--- a/src/main/resources/lib/ssb/utils/customHooks/calculatorHooks.tsx
+++ b/src/main/resources/lib/ssb/utils/customHooks/calculatorHooks.tsx
@@ -272,14 +272,16 @@ export const useSetupCalculator = ({
   }, [loading])
 
   useEffect(() => {
-    setStartYear({
+    setStartYear((prevState) => ({
       ...startYear,
+      error: prevState.error ? !isStartYearValid(prevState.value as string) : prevState.error,
       errorMsg: validYearErrorMsg,
-    })
-    setEndYear({
+    }))
+    setEndYear((prevState) => ({
       ...endYear,
+      error: prevState.error ? !isEndYearValid(prevState.value as string) : prevState.error,
       errorMsg: validYearErrorMsg,
-    })
+    }))
   }, [validMinYear])
 
   function getMonthLabel(month: string) {

--- a/src/main/resources/react4xp/_entries/BpiCalculator.tsx
+++ b/src/main/resources/react4xp/_entries/BpiCalculator.tsx
@@ -185,7 +185,6 @@ function BpiCalculator(props: BpiCalculatorProps) {
         } else {
           setErrorMessage(err.toString())
         }
-        console.log(errorMessage)
       })
       .finally(() => {
         setLoading(false)

--- a/src/main/resources/react4xp/_entries/BpiCalculator.tsx
+++ b/src/main/resources/react4xp/_entries/BpiCalculator.tsx
@@ -86,8 +86,8 @@ function BpiCalculator(props: BpiCalculatorProps) {
   })
 
   useEffect(() => {
-    // Only options "TOTAL = The whole country" and "001 = Oslo including Bærum" has data dating back to 1992
-    if (region.value.id === 'TOTAL' || region.value.id === '001') {
+    // Only options "TOTAL = The whole country", "001 = Oslo including Bærum", and '005 = Akershus excluding Bærum' has data dating back to 1992
+    if (region.value.id === 'TOTAL' || region.value.id === '001' || region.value.id === '005') {
       setValidMinYear(1992)
     } else {
       setValidMinYear(defaultValidMinYear)

--- a/src/main/resources/react4xp/_entries/BpiCalculator.tsx
+++ b/src/main/resources/react4xp/_entries/BpiCalculator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Title, Divider, RadioGroup, Dropdown, Input, Button } from '@statisticsnorway/ssb-component-library'
 import { Container, Row, Col, Form } from 'react-bootstrap'
 
@@ -34,6 +34,8 @@ function BpiCalculator(props: BpiCalculatorProps) {
     errorMsg: phrases.bpiValidateRegion,
     value: defaultRegion,
   })
+  const defaultValidMinYear = 2005
+  const [validMinYear, setValidMinYear] = useState(defaultValidMinYear)
 
   const defaultQuarterValue = { id: '', title: phrases.calculatorChooseQuarterPeriod }
   const {
@@ -78,10 +80,19 @@ function BpiCalculator(props: BpiCalculatorProps) {
     calculatorValidateYear: phrases.calculatorValidateYear,
     validMaxYear: lastUpdated.year,
     validMaxMonth: lastUpdated.month as string,
-    validMinYear: 1992,
+    validMinYear,
     months,
     calculatorNextQuarterPeriodText: phrases.calculatorNextQuarterPeriod,
   })
+
+  useEffect(() => {
+    // Only options "TOTAL = The whole country" and "001 = Oslo including Bærum" has data dating back to 1992
+    if (region.value.id === 'TOTAL' || region.value.id === '001') {
+      setValidMinYear(1992)
+    } else {
+      setValidMinYear(defaultValidMinYear)
+    }
+  }, [region])
 
   function onCategoryChange(id: string, value: CalculatorState['value']) {
     switch (id) {

--- a/src/main/resources/react4xp/_entries/BpiCalculator.tsx
+++ b/src/main/resources/react4xp/_entries/BpiCalculator.tsx
@@ -174,6 +174,7 @@ function BpiCalculator(props: BpiCalculatorProps) {
         } else {
           setErrorMessage(err.toString())
         }
+        console.log(errorMessage)
       })
       .finally(() => {
         setLoading(false)

--- a/src/main/resources/react4xp/calculator/CalculatorLayout.tsx
+++ b/src/main/resources/react4xp/calculator/CalculatorLayout.tsx
@@ -45,7 +45,7 @@ function CalculatorLayout({
   function renderNumber(value: string | number, type?: string) {
     const decimalSeparator = language === 'en' ? '.' : ','
     if (type === 'valute' || type === 'change') {
-      const valute = language === 'en' ? 'NOK' : 'kr'
+      const valute = language === 'en' ? ' NOK' : ' kr'
       const decimalScale = type === 'valute' ? 2 : 1
       return (
         <>

--- a/src/main/resources/services/bpiCalculator/bpiCalculator.ts
+++ b/src/main/resources/services/bpiCalculator/bpiCalculator.ts
@@ -11,6 +11,8 @@ import {
   getQuarterNumber,
   getPublishMonthByQuarter,
   getEndValue,
+  isStartIndexValid,
+  isEndIndexValid,
 } from '/lib/ssb/utils/calculatorUtils'
 import { HttpRequestParams } from '/lib/http-client'
 import { IndexResult } from '/lib/types/calculator'
@@ -133,21 +135,13 @@ function fetchBpiResults({
     (getPublishMonthByQuarter(getQuarterNumber(endQuarterPeriod)) as number).toString()
   )
 
-  if (
-    indexResult.startIndex !== null &&
-    indexResult.startIndex !== 0 &&
-    indexResult.endIndex !== null &&
-    indexResult.endIndex !== 0
-  ) {
-    const changeValue: number = getChangeValue(
-      indexResult.startIndex as number,
-      indexResult.endIndex as number,
-      chronological
-    )
+  const { startIndex, endIndex } = indexResult
+  if (isStartIndexValid(startIndex) && isEndIndexValid(endIndex)) {
+    const changeValue: number = getChangeValue(startIndex as number, endIndex as number, chronological)
     return {
       body: {
-        startIndex: indexResult.startIndex,
-        endIndex: indexResult.endIndex,
+        startIndex,
+        endIndex,
         change: getPercentageFromChangeValue(changeValue),
         endValue: getEndValue(startValue as string, indexResult),
       },
@@ -166,10 +160,9 @@ function fetchBpiResults({
     return {
       status: 500,
       body: {
-        error:
-          indexResult.startIndex === null || indexResult.startIndex === 0
-            ? calculatorServiceValidateStartQuarterPeriod
-            : calculatorServiceValidateEndQuarterPeriod,
+        error: !isStartIndexValid(startIndex)
+          ? calculatorServiceValidateStartQuarterPeriod
+          : calculatorServiceValidateEndQuarterPeriod,
       },
       contentType: 'application/json',
     }

--- a/src/main/resources/services/bpiCalculator/bpiCalculator.ts
+++ b/src/main/resources/services/bpiCalculator/bpiCalculator.ts
@@ -133,8 +133,17 @@ function fetchBpiResults({
     (getPublishMonthByQuarter(getQuarterNumber(endQuarterPeriod)) as number).toString()
   )
 
-  if (indexResult.startIndex != null && indexResult.endIndex != null) {
-    const changeValue: number = getChangeValue(indexResult.startIndex, indexResult.endIndex, chronological)
+  if (
+    indexResult.startIndex !== null &&
+    indexResult.startIndex !== 0 &&
+    indexResult.endIndex !== null &&
+    indexResult.endIndex !== 0
+  ) {
+    const changeValue: number = getChangeValue(
+      indexResult.startIndex as number,
+      indexResult.endIndex as number,
+      chronological
+    )
     return {
       body: {
         startIndex: indexResult.startIndex,
@@ -158,7 +167,7 @@ function fetchBpiResults({
       status: 500,
       body: {
         error:
-          indexResult.startIndex === null
+          indexResult.startIndex === null || indexResult.startIndex === 0
             ? calculatorServiceValidateStartQuarterPeriod
             : calculatorServiceValidateEndQuarterPeriod,
       },


### PR DESCRIPTION
- Adds space between amount and valute for results
- Fixes validation for invalid start- and end index
- - Move to calculatorUtils and implement in bpi calculator service
- Adds validation for year depending on region pick; most regions have data all the way back to 2005 and the remaining two are the only ones dating back to 1992

### Jira Issues!
[Link to ticket: MIM-2157](https://statistics-norway.atlassian.net/browse/MIM-2157)