### PR TITLE
Update cert and key for deploy to test; possibly a temp solution

### DIFF
--- a/.github/workflows/deploy_to_test.yaml
+++ b/.github/workflows/deploy_to_test.yaml
@@ -26,8 +26,8 @@ jobs:
           url: ${{ secrets.ENONIC_TEST_URL }}
           username: ${{ secrets.ENONIC_USER }}
           password: ${{ secrets.ENONIC_TEST_PASS }}
-          client_cert: ${{ secrets.ENONIC_CERT }}
-          client_key: ${{ secrets.ENONIC_KEY }}
+          client_cert: ${{ secrets.ENONIC_DEPLOY_CERT }}
+          client_key: ${{ secrets.ENONIC_DEPLOY_KEY }}
           app_jar: "./build/libs/*.jar"
       - name: Upload artifacts
         id: upload_artifacts


### PR DESCRIPTION
Since `ENONIC_CERT` and `ENONIC_KEY` is shared by all deploys, we will have to use these new env variables during the migration process