### PR TITLE
[MIM-2232] Mim 2232 create markdown part

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     include "com.enonic.xp:lib-value:${xpVersion}"
     include "no.item:lib-xp-cristin:1.3.2"
     include "no.item:lib-xp-time:1.0.4"
+    include "com.enonic.lib:lib-markdown:1.0.0"
 }
 
 repositories {

--- a/src/main/resources/index.d.ts
+++ b/src/main/resources/index.d.ts
@@ -37,6 +37,7 @@ declare global {
       export type LocalSearch = _PartComponent<'mimir:localSearch'>
       export type MailChimpForm = _PartComponent<'mimir:mailChimpForm'>
       export type Map = _PartComponent<'mimir:map'>
+      export type Markdown = _PartComponent<'mimir:markdown'>
       export type Maths = _PartComponent<'mimir:maths'>
       export type MenuBox = _PartComponent<'mimir:menuBox'>
       export type MenuDropdown = _PartComponent<'mimir:menuDropdown'>

--- a/src/main/resources/lib/ssb/utils/markdownUtils.ts
+++ b/src/main/resources/lib/ssb/utils/markdownUtils.ts
@@ -7,3 +7,10 @@ export function connectMarkdownRepo(): RepoConnection {
     principals: ['role:system.admin'],
   })
 }
+
+export function getMarkdownNode(nodeId: string, conn?: RepoConnection) {
+  if (!conn) {
+    conn = connectMarkdownRepo()
+  }
+  return conn.get(nodeId)
+}

--- a/src/main/resources/services/getMarkdownNodes/getMarkdownNodes.ts
+++ b/src/main/resources/services/getMarkdownNodes/getMarkdownNodes.ts
@@ -1,4 +1,4 @@
-import { connectMarkdownRepo } from '/lib/ssb/utils/markdownUtils'
+import { connectMarkdownRepo, getMarkdownNode } from '/lib/ssb/utils/markdownUtils'
 
 export const get = (): XP.Response => {
   const conn = connectMarkdownRepo()
@@ -9,7 +9,7 @@ export const get = (): XP.Response => {
   })
 
   const markdownNodes = result.hits.map((hit) => {
-    const node = conn.get(hit.id)
+    const node = getMarkdownNode(hit.id, conn)
     return {
       id: hit.id,
       displayName: node.displayName,

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -13,5 +13,7 @@ export function get(req: XP.Request): XP.Response {
     markdownRendered: renderMarkdown(node.markdown),
   }
 
-  return render(component, props, req)
+  return render(component, props, req, {
+    body: '<section class="xp-part"></section>',
+  })
 }

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -1,15 +1,13 @@
 import { getComponent } from '/lib/xp/portal'
-import { connectMarkdownRepo } from '/lib/ssb/utils/markdownUtils'
+import { getMarkdownNode } from '/lib/ssb/utils/markdownUtils'
 import { render } from '/lib/enonic/react4xp'
 import { render as renderMarkdown } from '/lib/markdown'
 
 export function get(req: XP.Request): XP.Response {
   const component = getComponent<XP.PartComponent.Markdown>()
 
-  const conn = connectMarkdownRepo()
-
   const nodeId = component.config.markdownNode
-  const node = conn.get(nodeId)
+  const node = getMarkdownNode(nodeId)
 
   const props = {
     markdownRendered: renderMarkdown(node.markdown),

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -1,0 +1,20 @@
+import { getComponent } from '/lib/xp/portal'
+import { connectMarkdownRepo } from '/lib/ssb/utils/markdownUtils'
+import { render } from '/lib/enonic/react4xp'
+import { render as renderMarkdown } from '/lib/markdown'
+
+export function get(req: XP.Request): XP.Response {
+  const component = getComponent<XP.PartComponent.Markdown>()
+
+  const conn = connectMarkdownRepo()
+
+  const nodeId = component.config.markdownNode
+  const node = conn.get(nodeId)
+  const markdownText = node.markdown
+
+  const props = {
+    markdownRendered: renderMarkdown(markdownText),
+  }
+
+  return render(component, props, req)
+}

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -10,10 +10,9 @@ export function get(req: XP.Request): XP.Response {
 
   const nodeId = component.config.markdownNode
   const node = conn.get(nodeId)
-  const markdownText = node.markdown
 
   const props = {
-    markdownRendered: renderMarkdown(markdownText),
+    markdownRendered: renderMarkdown(node.markdown),
   }
 
   return render(component, props, req)

--- a/src/main/resources/site/parts/markdown/markdown.tsx
+++ b/src/main/resources/site/parts/markdown/markdown.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { sanitize } from '/lib/ssb/utils/htmlUtils'
+
+export default (props) => (
+  <div
+    dangerouslySetInnerHTML={{
+      __html: sanitize(props.markdownRendered),
+    }}
+  />
+)

--- a/src/main/resources/site/parts/markdown/markdown.xml
+++ b/src/main/resources/site/parts/markdown/markdown.xml
@@ -1,0 +1,12 @@
+<part>
+    <display-name>Markdown</display-name>
+    <form>
+        <input name="markdownNode" type="CustomSelector">
+            <label>Markdown article</label>
+            <occurrences minimum="0" maximum="1"/>
+            <config>
+                <service>getMarkdownNodes</service>
+            </config>
+        </input>
+    </form>
+</part>


### PR DESCRIPTION
Created part to display markdown content.

- The part definition includes a custom selector that lets users choose the desired markdown content to render (specifically, it lets you choose among the nodes returned by the service getMarkdownNodes).
- The controller then does the following: 
    - Gets the raw markdown content from the chosen node.
    - Converts the markdown to html using the render function from Enonics markdown library: https://github.com/enonic/lib-markdown
    - Renders the react component (with the html from above as the only property). 
- For now, the React component just sanitizes the html and inserts it into a div. 


### Jira Issues!
[Link to ticket: MIM-2232](https://statistics-norway.atlassian.net/browse/MIM-2232)