### PR TITLE
[MIM-2310] Support pasting raw markdown

### DIFF
--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -6,13 +6,13 @@ import { render as renderMarkdown } from '/lib/markdown'
 export function get(req: XP.Request): XP.Response {
   const component = getComponent<XP.PartComponent.Markdown>()
 
-  const nodeId = component.config.markdownNode
+  const nodeId = component?.config.markdownNode
   const node = nodeId ? getMarkdownNode(nodeId) : null
 
-  const markdownFromNode = node ? node.markdown : null
-  const markdownFromTextArea = component.config.markdownTextArea
+  const markdownFromNode = node?.markdown
+  const markdownFromTextArea = component?.config.markdownTextArea
 
-  const markdown = markdownFromNode ? markdownFromNode : markdownFromTextArea
+  const markdown = markdownFromNode ?? markdownFromTextArea
 
   const props = {
     markdownRendered: renderMarkdown(markdown),

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -7,10 +7,15 @@ export function get(req: XP.Request): XP.Response {
   const component = getComponent<XP.PartComponent.Markdown>()
 
   const nodeId = component.config.markdownNode
-  const node = getMarkdownNode(nodeId)
+  const node = nodeId ? getMarkdownNode(nodeId) : null
+
+  const markdownFromNode = node ? node.markdown : null
+  const markdownFromTextArea = component.config.markdownTextArea
+
+  const markdown = markdownFromNode ? markdownFromNode : markdownFromTextArea
 
   const props = {
-    markdownRendered: renderMarkdown(node.markdown),
+    markdownRendered: renderMarkdown(markdown),
   }
 
   return render(component, props, req, {

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -5,17 +5,19 @@ import { render as renderMarkdown } from '/lib/markdown'
 
 export function get(req: XP.Request): XP.Response {
   const component = getComponent<XP.PartComponent.Markdown>()
+  const markdownContent = component?.config.markdownContent
 
-  const nodeId = component?.config.markdownNode
-  const node = nodeId ? getMarkdownNode(nodeId) : null
-
-  const markdownFromNode = node?.markdown
-  const markdownFromTextArea = component?.config.markdownTextArea
-
-  const markdown = markdownFromNode ?? markdownFromTextArea
+  let markdownText
+  if (markdownContent?._selected == 'fromNode') {
+    const nodeId = markdownContent?.fromNode.nodeId ?? ''
+    const node = nodeId ? getMarkdownNode(nodeId) : null
+    markdownText = node?.markdown
+  } else {
+    markdownText = markdownContent?.fromText.text
+  }
 
   const props = {
-    markdownRendered: renderMarkdown(markdown),
+    markdownRendered: renderMarkdown(markdownText),
   }
 
   return render(component, props, req, {

--- a/src/main/resources/site/parts/markdown/markdown.xml
+++ b/src/main/resources/site/parts/markdown/markdown.xml
@@ -3,10 +3,14 @@
     <form>
         <input name="markdownNode" type="CustomSelector">
             <label>Markdown article</label>
-            <occurrences minimum="0" maximum="1"/>
+            <occurrences minimum="0" maximum="1" />
             <config>
                 <service>getMarkdownNodes</service>
             </config>
+        </input>
+        <input name="rawMarkdownText" type="TextArea">
+            <label>Raw Markdown text</label>
+            <occurrences minimum="0" maximum="1" />
         </input>
     </form>
 </part>

--- a/src/main/resources/site/parts/markdown/markdown.xml
+++ b/src/main/resources/site/parts/markdown/markdown.xml
@@ -7,7 +7,7 @@
             <occurrences minimum="1" maximum="1" />
             <help-text>Velg en av måtene å legge til Markdown-innhold.</help-text>
             <options minimum="1" maximum="1">
-                <option name="fromNodeOption">
+                <option name="fromNode">
                     <label>Artikkel fra databasen</label>
                     <help-text>Velg en Markdown-artikkel fra databasen</help-text>
                     <items>
@@ -20,7 +20,7 @@
                         </input>
                     </items>
                 </option>
-                <option name="fromTextOption">
+                <option name="fromText">
                     <label>Rå tekst</label>
                     <help-text>Lim inn rå Markdown-tekst</help-text>
                     <items>

--- a/src/main/resources/site/parts/markdown/markdown.xml
+++ b/src/main/resources/site/parts/markdown/markdown.xml
@@ -8,7 +8,7 @@
                 <service>getMarkdownNodes</service>
             </config>
         </input>
-        <input name="rawMarkdownText" type="TextArea">
+        <input name="markdownTextArea" type="TextArea">
             <label>Raw Markdown text</label>
             <occurrences minimum="0" maximum="1" />
         </input>

--- a/src/main/resources/site/parts/markdown/markdown.xml
+++ b/src/main/resources/site/parts/markdown/markdown.xml
@@ -1,16 +1,36 @@
 <part>
     <display-name>Markdown</display-name>
     <form>
-        <input name="markdownNode" type="CustomSelector">
-            <label>Markdown article</label>
-            <occurrences minimum="0" maximum="1" />
-            <config>
-                <service>getMarkdownNodes</service>
-            </config>
-        </input>
-        <input name="markdownTextArea" type="TextArea">
-            <label>Raw Markdown text</label>
-            <occurrences minimum="0" maximum="1" />
-        </input>
+        <option-set name="markdownContent">
+            <label>Innhold</label>
+            <expanded>true</expanded>
+            <occurrences minimum="1" maximum="1" />
+            <help-text>Velg en av måtene å legge til Markdown-innhold.</help-text>
+            <options minimum="1" maximum="1">
+                <option name="fromNodeOption">
+                    <label>Artikkel fra databasen</label>
+                    <help-text>Velg en Markdown-artikkel fra databasen</help-text>
+                    <items>
+                        <input name="nodeId" type="CustomSelector">
+                            <label>Markdown-artikkel</label>
+                            <occurrences minimum="0" maximum="1" />
+                            <config>
+                                <service>getMarkdownNodes</service>
+                            </config>
+                        </input>
+                    </items>
+                </option>
+                <option name="fromTextOption">
+                    <label>Rå tekst</label>
+                    <help-text>Lim inn rå Markdown-tekst</help-text>
+                    <items>
+                        <input name="text" type="TextArea">
+                            <label>Rå Markdown-tekst</label>
+                            <occurrences minimum="0" maximum="1" />
+                        </input>
+                    </items>
+                </option>
+            </options>
+        </option-set>
     </form>
 </part>


### PR DESCRIPTION
**Currently:**
* It's only possible to render Markdown-content received through the postMarkdown-endpoint.
* Implementation: we have a Markdown part that can be configured by choosing a node from the repo *no.ssb.pubmd*. This repo stores the Markdown content received through the endpoint. 

**Desired feature:**
* When adding a Markdown part to a page, an alternative configuration of the part is to paste raw Markdown content. 

**Solution:**
* This PR adds an additional text area input in the part definition, where raw markdown can be pasted.
* The first input (choosing a node) has priority, while the second input (text area) is a fallback when the first input has no value. 

**Limitations:**
* Choosing only one of the inputs is not enforced on the user, i.e. the user is allowed to use both of the input fields, in which case only the first input will be used. Can we make the inputs mutually exclusive in the user interface? 

### Jira Issues!
[Link to ticket: MIM-2310](https://statistics-norway.atlassian.net/browse/MIM-2310)