### PR TITLE
feat: added markdown content type [MIM-2343]

### DIFF
--- a/src/main/resources/site/content-types/markdown/markdown.xml
+++ b/src/main/resources/site/content-types/markdown/markdown.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<content-type>
+	<display-name>Markdown</display-name>
+	<super-type>base:structured</super-type>
+	<form>
+		<input name="nodeId" type="CustomSelector">
+			<label>Markdown-artikkel</label>
+			<occurrences minimum="1" maximum="1" />
+			<config>
+				<service>getMarkdownNodes</service>
+			</config>
+		</input>
+	</form>
+</content-type>


### PR DESCRIPTION
This PR adds a markdown content type with one data property, _nodeId_, referring to the node where the actual markdown text is stored. 

This is the first step in extending the postMarkdown service to include a preview URL in its response. 

Link to ticket: MIM-2343