### PR TITLE
feat: preview creation in postMarkdown service [MIM-2344]

### DIFF
--- a/src/main/resources/services/postMarkdown/postMarkdown.ts
+++ b/src/main/resources/services/postMarkdown/postMarkdown.ts
@@ -1,4 +1,6 @@
 import { exists as existsContent, get as getContent } from '/lib/xp/content'
+import { get as getContext, run as runWithContext } from '/lib/xp/context'
+import { type ContextCallback } from '/lib/ssb/repo/common'
 import { connectMarkdownRepo } from '/lib/ssb/utils/markdownUtils'
 
 export const post = (req: XP.Request): XP.Response => {
@@ -29,9 +31,11 @@ export const post = (req: XP.Request): XP.Response => {
 
   const previewId = typeof node.previewId === 'string' ? node.previewId : ''
   const previewExists = previewId
-    ? existsContent({
-        key: previewId,
-      })
+    ? withDraftContext(() =>
+        existsContent({
+          key: previewId,
+        })
+      )
     : false
 
   let previewPath: string
@@ -54,9 +58,17 @@ export const post = (req: XP.Request): XP.Response => {
 }
 
 function getPreviewPath(previewId: string): string {
-  const content = getContent({
-    key: previewId,
-  })
+  const content = withDraftContext(() =>
+    getContent({
+      key: previewId,
+    })
+  )
   const contentPath = content?._path ?? ''
   return '/admin/site/preview/default/draft' + contentPath
+}
+
+function withDraftContext<T>(callback: ContextCallback<T>): T {
+  const draftContext = getContext()
+  draftContext.branch = 'draft'
+  return runWithContext(draftContext, callback)
 }

--- a/src/main/resources/services/postMarkdown/postMarkdown.ts
+++ b/src/main/resources/services/postMarkdown/postMarkdown.ts
@@ -13,9 +13,9 @@ export const post = (req: XP.Request): XP.Response => {
   const nodeId = typeof json._id === 'string' ? json._id : ''
   const nodeExists = nodeId ? conn.exists(nodeId) : false
 
-  let result
+  let node
   if (nodeExists) {
-    result = conn.modify({
+    node = conn.modify({
       key: nodeId,
       editor: (node) => ({
         ...node,
@@ -23,12 +23,16 @@ export const post = (req: XP.Request): XP.Response => {
       }),
     })
   } else {
-    result = conn.create(data)
+    node = conn.create(data)
+  }
+
+  const body = {
+    _id: node._id,
   }
 
   return {
     status: 200,
-    body: result,
+    body: body,
     contentType: 'application/json',
   }
 }

--- a/src/main/resources/services/postMarkdown/postMarkdown.ts
+++ b/src/main/resources/services/postMarkdown/postMarkdown.ts
@@ -1,3 +1,4 @@
+import { exists as existsContent } from '/lib/xp/content'
 import { connectMarkdownRepo } from '/lib/ssb/utils/markdownUtils'
 
 export const post = (req: XP.Request): XP.Response => {
@@ -25,6 +26,15 @@ export const post = (req: XP.Request): XP.Response => {
   } else {
     node = conn.create(data)
   }
+
+  const previewId = typeof node.previewId === 'string' ? node.previewId : ''
+  const previewExists = previewId
+    ? existsContent({
+        key: previewId,
+      })
+    : false
+
+  log.info(previewExists)
 
   const body = {
     _id: node._id,

--- a/src/main/resources/services/postMarkdown/postMarkdown.ts
+++ b/src/main/resources/services/postMarkdown/postMarkdown.ts
@@ -1,4 +1,4 @@
-import { exists as existsContent } from '/lib/xp/content'
+import { exists as existsContent, get as getContent } from '/lib/xp/content'
 import { connectMarkdownRepo } from '/lib/ssb/utils/markdownUtils'
 
 export const post = (req: XP.Request): XP.Response => {
@@ -34,10 +34,16 @@ export const post = (req: XP.Request): XP.Response => {
       })
     : false
 
-  log.info(previewExists)
+  let previewPath: string
+  if (previewExists) {
+    previewPath = getPreviewPath(previewId)
+  } else {
+    previewPath = ''
+  }
 
   const body = {
     _id: node._id,
+    previewPath: previewPath,
   }
 
   return {
@@ -45,4 +51,12 @@ export const post = (req: XP.Request): XP.Response => {
     body: body,
     contentType: 'application/json',
   }
+}
+
+function getPreviewPath(previewId: string): string {
+  const content = getContent({
+    key: previewId,
+  })
+  const contentPath = content?._path ?? ''
+  return '/admin/site/preview/default/draft' + contentPath
 }


### PR DESCRIPTION
Before this PR, the _postMarkdown_  service controller does the following: 

1. Creates (or modifies) a node to store the markdown text from the request.

This PR adds the following steps to the controller: 

2. Check if the property _previewId_ exists in the node.
3. Check if _previewId_ references an existing content.
4. If both steps above are true, go to the next step. If not, create a content first:

    * In the content, add a reference to the node (in the _nodeId_ property).
    * In the node, add a reference to the content (in the _previewId_ property).

5. Fetch the path of the content's preview URL and add it to the response body. 

**Limitations/considerations:**

The path in the last step will look something like _/admin/site/preview/default/draft/ssb/pubmd/markdown_. Two things to consider are:
* We assume that the base URL is known on the client side (it is needed to connect to the endpoint). With this assumption in mind, it suffices to send the path component of the preview URL back to the client. The full URL will be constructed by the client if necessary.
* We create a content folder *pubmd* dedicated to storing previews. This "pollutes" Content Studio with a folder which is only meant to be accessed by the *pubmd* service account, i.e. not by Content Studio users. Creating and storing content seems necessary in order to send back previews to the client. The *pubmd* folder can be emptied regularly without any consequences for the clients of the _postMarkdown_ service; new previews will always be created when necessary. 

Link to ticket: MIM-2344