### PR TITLE
feat: Fetch XP Content data for Editorial Cards part [MIM-2058]

### DIFF
--- a/src/main/resources/lib/ssb/utils/imageUtils.ts
+++ b/src/main/resources/lib/ssb/utils/imageUtils.ts
@@ -30,7 +30,7 @@ export function imageUrl(params: ImageUrlParams) {
   return xpImageUrl(params)
 }
 
-export function getXPContentImage(XPContent: Content, imageDimensions: ImageDimensions) {
+export function getImageFromContent(XPContent: Content, imageDimensions: ImageDimensions) {
   let imageSrc: string | undefined
   let imageAlt: string | undefined = ''
 

--- a/src/main/resources/lib/ssb/utils/imageUtils.ts
+++ b/src/main/resources/lib/ssb/utils/imageUtils.ts
@@ -34,7 +34,7 @@ export function getImageFromContent(XPContent: Content, imageDimensions: ImageDi
   let imageSrc: string | undefined
   let imageAlt: string | undefined = ''
 
-  const { scale, format, placeholderWidth, placeholderHeight } = imageDimensions
+  const { scale, placeholderWidth, placeholderHeight } = imageDimensions
   if (!XPContent?.x['com-enonic-app-metafields']?.['meta-data']?.seoImage) {
     imageSrc = imagePlaceholder({
       width: placeholderWidth,
@@ -45,7 +45,7 @@ export function getImageFromContent(XPContent: Content, imageDimensions: ImageDi
     imageSrc = imageUrl({
       id: image,
       scale,
-      format,
+      format: 'jpg',
     })
     imageAlt = getImageAlt(image) ? getImageAlt(image) : ''
   }
@@ -55,7 +55,6 @@ export function getImageFromContent(XPContent: Content, imageDimensions: ImageDi
 
 interface ImageDimensions {
   scale: ImageUrlParams['scale']
-  format: string
   placeholderWidth: number
   placeholderHeight: number
 }

--- a/src/main/resources/lib/ssb/utils/imageUtils.ts
+++ b/src/main/resources/lib/ssb/utils/imageUtils.ts
@@ -1,5 +1,5 @@
 import { get, Content } from '/lib/xp/content'
-import { imageUrl as xpImageUrl, type ImageUrlParams } from '/lib/xp/portal'
+import { imageUrl as xpImageUrl, type ImageUrlParams, imagePlaceholder } from '/lib/xp/portal'
 
 export function getImageCaption(imageId: string): string | undefined {
   const imageContent: Content<MediaImage> | null = get({
@@ -28,4 +28,34 @@ export function imageUrl(params: ImageUrlParams) {
   }
 
   return xpImageUrl(params)
+}
+
+export function getXPContentImage(XPContent: Content, imageDimensions: ImageDimensions) {
+  let imageSrc: string | undefined
+  let imageAlt: string | undefined = ''
+
+  const { scale, format, placeholderWidth, placeholderHeight } = imageDimensions
+  if (!XPContent?.x['com-enonic-app-metafields']?.['meta-data']?.seoImage) {
+    imageSrc = imagePlaceholder({
+      width: placeholderWidth,
+      height: placeholderHeight,
+    })
+  } else {
+    const image: string = XPContent?.x['com-enonic-app-metafields']?.['meta-data']?.seoImage
+    imageSrc = imageUrl({
+      id: image,
+      scale,
+      format,
+    })
+    imageAlt = getImageAlt(image) ? getImageAlt(image) : ''
+  }
+
+  return { imageSrc, imageAlt }
+}
+
+interface ImageDimensions {
+  scale: ImageUrlParams['scale']
+  format: string
+  placeholderWidth: number
+  placeholderHeight: number
 }

--- a/src/main/resources/lib/ssb/utils/utils.ts
+++ b/src/main/resources/lib/ssb/utils/utils.ts
@@ -215,22 +215,22 @@ export function getLinkTargetXPContent(
 }
 
 export function getSubTitle(XPContent: Content<Article>, language: string): string {
-  const articleType = XPContent.data.articleType ? `contentType.search.${XPContent.data.articleType}` : 'articleName'
+  const articleType = XPContent?.data.articleType ? `contentType.search.${XPContent.data.articleType}` : 'articleName'
   const articleNamePhrase: string = localize({
     key: articleType,
     locale: language,
   })
 
   let type = ''
-  if (XPContent.type === `${app.name}:article`) {
+  if (XPContent?.type === `${app.name}:article`) {
     type = articleNamePhrase
   }
 
   let prettyDate: string | undefined = ''
-  if (XPContent.publish && XPContent.publish.from) {
+  if (XPContent?.publish && XPContent?.publish.from) {
     prettyDate = formatDate(XPContent.publish.from, 'PPP', language)
   } else {
-    prettyDate = formatDate(XPContent.createdTime, 'PPP', language)
+    prettyDate = formatDate(XPContent?.createdTime, 'PPP', language)
   }
 
   return `${type ? `${type} / ` : ''}${prettyDate ? prettyDate : ''}`

--- a/src/main/resources/lib/ssb/utils/utils.ts
+++ b/src/main/resources/lib/ssb/utils/utils.ts
@@ -213,7 +213,7 @@ export function getLinkTargetXPContent(
   return null
 }
 
-export function getSubTitle(XPContent: Content<Article>, language: string): string {
+export function getSubtitleForContent(XPContent: Content<Article>, language: string): string {
   const articleType = XPContent?.data.articleType ? `contentType.search.${XPContent.data.articleType}` : 'articleName'
   const articleNamePhrase: string = localize({
     key: articleType,

--- a/src/main/resources/lib/ssb/utils/utils.ts
+++ b/src/main/resources/lib/ssb/utils/utils.ts
@@ -1,7 +1,7 @@
 import { localize } from '/lib/xp/i18n'
 import { get, getAttachmentStream, ByteSource, Content } from '/lib/xp/content'
 
-import { getContent, pageUrl, assetUrl, imagePlaceholder, ImageUrlParams } from '/lib/xp/portal'
+import { getContent, pageUrl, assetUrl } from '/lib/xp/portal'
 import { readLines } from '/lib/xp/io'
 import { type PreliminaryData } from '/lib/types/xmlParser'
 import { formatDate, fromNow } from '/lib/ssb/utils/dateUtils'
@@ -9,7 +9,6 @@ import { type SourceList, type SourcesConfig } from '/lib/types/sources'
 import { type RowValue } from '/lib/types/util'
 import { type Article, type Header } from '/site/content-types'
 import { type ProfiledBox as ProfiledBoxPartConfig } from '/site/parts/profiledBox'
-import { imageUrl, getImageAlt } from './imageUtils'
 
 function numberWithSpaces(x: number | string): string {
   const parts: Array<string> = x.toString().split('.')
@@ -236,40 +235,10 @@ export function getSubTitle(XPContent: Content<Article>, language: string): stri
   return `${type ? `${type} / ` : ''}${prettyDate ? prettyDate : ''}`
 }
 
-export function getXPContentImage(XPContent: Content, imageDimensions: ImageDimensions) {
-  let imageSrc: string | undefined
-  let imageAlt: string | undefined = ''
-
-  const { scale, format, placeholderWidth, placeholderHeight } = imageDimensions
-  if (!XPContent?.x['com-enonic-app-metafields']?.['meta-data']?.seoImage) {
-    imageSrc = imagePlaceholder({
-      width: placeholderWidth,
-      height: placeholderHeight,
-    })
-  } else {
-    const image: string = XPContent?.x['com-enonic-app-metafields']?.['meta-data']?.seoImage
-    imageSrc = imageUrl({
-      id: image,
-      scale,
-      format,
-    })
-    imageAlt = getImageAlt(image) ? getImageAlt(image) : ''
-  }
-
-  return { imageSrc, imageAlt }
-}
-
 interface ContentSearchPageResult {
   contentId?: string
 }
 
 interface ManualSearchPageResult {
   url?: string
-}
-
-interface ImageDimensions {
-  scale: ImageUrlParams['scale']
-  format: string
-  placeholderWidth: number
-  placeholderHeight: number
 }

--- a/src/main/resources/lib/ssb/utils/utils.ts
+++ b/src/main/resources/lib/ssb/utils/utils.ts
@@ -204,7 +204,7 @@ export function getLinkTargetUrl(urlContentSelector: ProfiledBoxPartConfig['urlC
   }
 }
 
-export function getLinkTargetXPContent(
+export function getLinkTargetContent(
   urlContentSelector: ProfiledBoxPartConfig['urlContentSelector']
 ): Content<Article> | null {
   if (urlContentSelector?._selected == 'optionXPContent') {

--- a/src/main/resources/lib/ssb/utils/utils.ts
+++ b/src/main/resources/lib/ssb/utils/utils.ts
@@ -229,7 +229,7 @@ export function getSubTitle(XPContent: Content<Article> | Content<Statistics>, l
 
   if (XPContent.type === `${app.name}:statistics`) {
     type = localize({
-      key: 'contentType.search.statistics',
+      key: 'contentType.search.statistikk',
       locale: language,
     })
   }

--- a/src/main/resources/lib/ssb/utils/utils.ts
+++ b/src/main/resources/lib/ssb/utils/utils.ts
@@ -1,3 +1,4 @@
+import { localize } from '/lib/xp/i18n'
 import { get, getAttachmentStream, ByteSource, Content } from '/lib/xp/content'
 
 import { getContent, pageUrl, assetUrl } from '/lib/xp/portal'
@@ -6,7 +7,7 @@ import { type PreliminaryData } from '/lib/types/xmlParser'
 import { formatDate, fromNow } from '/lib/ssb/utils/dateUtils'
 import { type SourceList, type SourcesConfig } from '/lib/types/sources'
 import { type RowValue } from '/lib/types/util'
-import { type Header } from '/site/content-types'
+import { Statistics, type Article, type Header } from '/site/content-types'
 import { type ProfiledBox as ProfiledBoxPartConfig } from '/site/parts/profiledBox'
 
 function numberWithSpaces(x: number | string): string {
@@ -201,6 +202,46 @@ export function getLinkTargetUrl(urlContentSelector: ProfiledBoxPartConfig['urlC
         })
       : ''
   }
+}
+
+export function getLinkTargetXPContent(
+  urlContentSelector: ProfiledBoxPartConfig['urlContentSelector']
+): Content<Article> | null {
+  if (urlContentSelector?._selected == 'optionXPContent') {
+    return get({ key: urlContentSelector.optionXPContent.xpContent as string })
+  }
+  return null
+}
+
+export function getSubTitle(XPContent: Content<Article> | Content<Statistics>, language: string): string {
+  const articleType = (XPContent as Content<Article>).data.articleType
+    ? `contentType.search.${(XPContent as Content<Article>).data.articleType}`
+    : 'articleName'
+  const articleNamePhrase: string = localize({
+    key: articleType,
+    locale: language,
+  })
+
+  let type = ''
+  if (XPContent.type === `${app.name}:article`) {
+    type = articleNamePhrase
+  }
+
+  if (XPContent.type === `${app.name}:statistics`) {
+    type = localize({
+      key: 'contentType.search.statistics',
+      locale: language,
+    })
+  }
+
+  let prettyDate: string | undefined = ''
+  if (XPContent.publish && XPContent.publish.from) {
+    prettyDate = formatDate(XPContent.publish.from, 'PPP', language)
+  } else {
+    prettyDate = formatDate(XPContent.createdTime, 'PPP', language)
+  }
+
+  return `${type ? `${type} / ` : ''}${prettyDate ? prettyDate : ''}`
 }
 
 interface ContentSearchPageResult {

--- a/src/main/resources/site/parts/articleArchive/articleArchive.ts
+++ b/src/main/resources/site/parts/articleArchive/articleArchive.ts
@@ -11,7 +11,7 @@ import {
   type ParsedArticles,
   type ParsedArticleData,
 } from '/lib/types/partTypes/articleArchive'
-import { getSubTitle } from '/lib/ssb/utils/utils'
+import { getSubtitleForContent } from '/lib/ssb/utils/utils'
 import { type Article, type ArticleArchive } from '/site/content-types'
 
 export function get(req: XP.Request): XP.Response {
@@ -126,7 +126,7 @@ export function parseArticleData(pageId: string, start: number, count: number, l
         JSON.stringify(articleContent.publish) != '{}' && articleContent.createdTime
           ? formatDate(articleContent.publish?.from, 'yyyy', language)
           : formatDate(articleContent.createdTime, 'yyyy', language),
-      subtitle: getSubTitle(articleContent, language),
+      subtitle: getSubtitleForContent(articleContent, language),
       href: pageUrl({
         id: articleContent._id,
       }),

--- a/src/main/resources/site/parts/articleArchive/articleArchive.ts
+++ b/src/main/resources/site/parts/articleArchive/articleArchive.ts
@@ -11,6 +11,7 @@ import {
   type ParsedArticles,
   type ParsedArticleData,
 } from '/lib/types/partTypes/articleArchive'
+import { getSubTitle } from '/lib/ssb/utils/utils'
 import { type Article, type ArticleArchive } from '/site/content-types'
 
 export function get(req: XP.Request): XP.Response {
@@ -87,22 +88,6 @@ function renderPart(req: XP.Request) {
   })
 }
 
-function getSubTitle(articleContent: Content<Article>, articleNamePhrase: string, language: string): string {
-  let type = ''
-  if (articleContent.type === `${app.name}:article`) {
-    type = articleNamePhrase
-  }
-
-  let prettyDate: string | undefined = ''
-  if (articleContent.publish && articleContent.publish.from) {
-    prettyDate = formatDate(articleContent.publish.from, 'PPP', language)
-  } else {
-    prettyDate = formatDate(articleContent.createdTime, 'PPP', language)
-  }
-
-  return `${type ? `${type} / ` : ''}${prettyDate ? prettyDate : ''}`
-}
-
 export function parseArticleData(pageId: string, start: number, count: number, language: string): ParsedArticles {
   const articles = query<Content<Article>>({
     start,
@@ -135,20 +120,13 @@ export function parseArticleData(pageId: string, start: number, count: number, l
   })
 
   const parsedArticles: Array<ParsedArticleData> = articles.hits.map((articleContent) => {
-    const articleType = articleContent.data.articleType
-      ? `contentType.search.${articleContent.data.articleType}`
-      : 'articleName'
-    const articleNamePhrase: string = localize({
-      key: articleType,
-      locale: language,
-    })
     return {
       year:
         // checking against an empty articleContent.publish object to throw a false
         JSON.stringify(articleContent.publish) != '{}' && articleContent.createdTime
           ? formatDate(articleContent.publish?.from, 'yyyy', language)
           : formatDate(articleContent.createdTime, 'yyyy', language),
-      subtitle: getSubTitle(articleContent, articleNamePhrase, language),
+      subtitle: getSubTitle(articleContent, language),
       href: pageUrl({
         id: articleContent._id,
       }),

--- a/src/main/resources/site/parts/profiledBox/profiledBox.html
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.html
@@ -1,1 +1,0 @@
-<section class="xp-part part-profiled-box container" data-th-id="${profiledBoxId}"></section>

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -1,5 +1,4 @@
 import { getContent, getComponent, Content, type ImageUrlParams } from '/lib/xp/portal'
-import { render } from '/lib/thymeleaf'
 import {
   getLinkTargetUrl,
   getLinkTargetXPContent,
@@ -16,8 +15,6 @@ import { renderError } from '/lib/ssb/error/error'
 import { type ProfiledBoxProps } from '/lib/types/partTypes/profiledBox'
 import { type Article } from '/site/content-types'
 import { type ProfiledBox as ProfiledBoxPartConfig } from '.'
-
-const view = resolve('profiledBox.html')
 
 export function get(req: XP.Request): XP.Response {
   try {
@@ -40,13 +37,10 @@ function renderPart(req: XP.Request): XP.Response {
 
   const language: string = page.language === 'en' || page.language === 'nn' ? page.language : 'nb'
   const id: string = 'profiled-box-' + randomUnsafeString()
-  const body: string = render(view, {
-    profiledBoxId: id,
-  })
 
   return r4xpRender('site/parts/profiledBox/profiledBox', parseProfiledBoxProps(config, language), req, {
-    id: id,
-    body: body,
+    id,
+    body: `<section class="xp-part part-profiled-box container" id="${id}"></section>`,
     hydrate: false,
   })
 }

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -3,7 +3,7 @@ import {
   getLinkTargetUrl,
   getLinkTargetXPContent,
   getProfiledCardAriaLabel,
-  getSubTitle,
+  getSubtitleForContent,
   randomUnsafeString,
 } from '/lib/ssb/utils/utils'
 import { render as r4xpRender } from '/lib/enonic/react4xp'
@@ -79,7 +79,7 @@ function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string):
   const subTitle =
     config.content && config.date
       ? getSubtitleFromConfig(config.content, config.date, language)
-      : (getSubTitle(linkTargetXPContent as Content<Article>, language) ?? '')
+      : (getSubtitleForContent(linkTargetXPContent as Content<Article>, language) ?? '')
 
   const imageWidth = 315
   const imageHeight = 215

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -81,13 +81,17 @@ function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string):
     config.content && config.date
       ? getSubtitleFromConfig(config.content, config.date, language)
       : (getSubTitle(linkTargetXPContent as Content<Article>, language) ?? '')
+
+  const imageWidth = 315
+  const imageHeight = 215
   const imageDimensions = {
-    scale: 'block(315, 215)' as ImageUrlParams['scale'],
+    scale: `block(${imageWidth}, ${imageHeight})` as ImageUrlParams['scale'],
     format: 'jpg',
-    placeholderWidth: 315,
-    placeholderHeight: 215,
+    placeholderWidth: imageWidth,
+    placeholderHeight: imageHeight,
   }
   const { imageSrc, imageAlt } = getXPContentImage(linkTargetXPContent as Content<Article>, imageDimensions)
+
   return {
     imgUrl: config.image
       ? imageUrl({

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -78,8 +78,8 @@ function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string):
 
   const title = config.title ?? linkTargetXPContent?.displayName ?? ''
   const subTitle =
-    config.content || config.date
-      ? getSubtitleFromConfig(config.content, config.date, language) // TODO: If either config.content or config.date is empty, what should be returned?
+    config.content && config.date
+      ? getSubtitleFromConfig(config.content, config.date, language)
       : (getSubTitle(linkTargetXPContent as Content<Article>, language) ?? '')
   const imageDimensions = {
     scale: 'block(315, 215)' as ImageUrlParams['scale'],

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -1,7 +1,7 @@
 import { getContent, getComponent, Content, type ImageUrlParams } from '/lib/xp/portal'
 import {
   getLinkTargetUrl,
-  getLinkTargetXPContent,
+  getLinkTargetContent,
   getProfiledCardAriaLabel,
   getSubtitleForContent,
   randomUnsafeString,
@@ -73,13 +73,13 @@ function getTitleSize(title: string): string {
 
 function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string): ProfiledBoxProps {
   const urlContentSelector: ProfiledBoxPartConfig['urlContentSelector'] = config.urlContentSelector
-  const linkTargetXPContent = getLinkTargetXPContent(config.urlContentSelector)
+  const linkTargetContent = getLinkTargetContent(config.urlContentSelector)
 
-  const title = config.title ?? linkTargetXPContent?.displayName ?? ''
+  const title = config.title ?? linkTargetContent?.displayName ?? ''
   const subTitle =
     config.content && config.date
       ? getSubtitleFromConfig(config.content, config.date, language)
-      : (getSubtitleForContent(linkTargetXPContent as Content<Article>, language) ?? '')
+      : (getSubtitleForContent(linkTargetContent as Content<Article>, language) ?? '')
 
   const imageWidth = 315
   const imageHeight = 215
@@ -89,7 +89,7 @@ function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string):
     placeholderWidth: imageWidth,
     placeholderHeight: imageHeight,
   }
-  const { imageSrc, imageAlt } = getImageFromContent(linkTargetXPContent as Content<Article>, imageDimensions)
+  const { imageSrc, imageAlt } = getImageFromContent(linkTargetContent as Content<Article>, imageDimensions)
 
   return {
     imgUrl: config.image
@@ -104,7 +104,7 @@ function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string):
     href: getLinkTargetUrl(urlContentSelector),
     subTitle,
     title,
-    preambleText: config.preamble ?? (linkTargetXPContent?.data?.ingress as string) ?? '',
+    preambleText: config.preamble ?? (linkTargetContent?.data?.ingress as string) ?? '',
     titleSize: getTitleSize(title),
     ariaLabel: getProfiledCardAriaLabel(subTitle),
   }

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -8,7 +8,7 @@ import {
 } from '/lib/ssb/utils/utils'
 import { render as r4xpRender } from '/lib/enonic/react4xp'
 import { formatDate } from '/lib/ssb/utils/dateUtils'
-import { imageUrl, getImageAlt, getXPContentImage } from '/lib/ssb/utils/imageUtils'
+import { imageUrl, getImageAlt, getImageFromContent } from '/lib/ssb/utils/imageUtils'
 
 import { renderError } from '/lib/ssb/error/error'
 import { type ProfiledBoxProps } from '/lib/types/partTypes/profiledBox'
@@ -89,7 +89,7 @@ function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string):
     placeholderWidth: imageWidth,
     placeholderHeight: imageHeight,
   }
-  const { imageSrc, imageAlt } = getXPContentImage(linkTargetXPContent as Content<Article>, imageDimensions)
+  const { imageSrc, imageAlt } = getImageFromContent(linkTargetXPContent as Content<Article>, imageDimensions)
 
   return {
     imgUrl: config.image

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -85,7 +85,6 @@ function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string):
   const imageHeight = 215
   const imageDimensions = {
     scale: `block(${imageWidth}, ${imageHeight})` as ImageUrlParams['scale'],
-    format: 'jpg',
     placeholderWidth: imageWidth,
     placeholderHeight: imageHeight,
   }
@@ -96,7 +95,7 @@ function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string):
       ? imageUrl({
           id: config.image,
           scale: imageDimensions.scale,
-          format: imageDimensions.format,
+          format: 'jpg',
         })
       : (imageSrc ?? ''),
     imageAltText: config.image ? getImageAlt(config.image) : (imageAlt ?? ''),

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -1,12 +1,20 @@
-import { getContent, getComponent } from '/lib/xp/portal'
+import { getContent, getComponent, Content, type ImageUrlParams } from '/lib/xp/portal'
 import { render } from '/lib/thymeleaf'
-import { getLinkTargetUrl, getProfiledCardAriaLabel, randomUnsafeString } from '/lib/ssb/utils/utils'
+import {
+  getLinkTargetUrl,
+  getLinkTargetXPContent,
+  getProfiledCardAriaLabel,
+  getSubTitle,
+  getXPContentImage,
+  randomUnsafeString,
+} from '/lib/ssb/utils/utils'
 import { render as r4xpRender } from '/lib/enonic/react4xp'
 import { formatDate } from '/lib/ssb/utils/dateUtils'
 import { imageUrl, getImageAlt } from '/lib/ssb/utils/imageUtils'
 
 import { renderError } from '/lib/ssb/error/error'
 import { type ProfiledBoxProps } from '/lib/types/partTypes/profiledBox'
+import { type Article } from '/site/content-types'
 import { type ProfiledBox as ProfiledBoxPartConfig } from '.'
 
 const view = resolve('profiledBox.html')
@@ -31,38 +39,19 @@ function renderPart(req: XP.Request): XP.Response {
   if (!config) throw Error('No part found')
 
   const language: string = page.language === 'en' || page.language === 'nn' ? page.language : 'nb'
-  const urlContentSelector: ProfiledBoxPartConfig['urlContentSelector'] = config.urlContentSelector
   const id: string = 'profiled-box-' + randomUnsafeString()
   const body: string = render(view, {
     profiledBoxId: id,
   })
 
-  const title = config.title
-  const subTitle = getSubtitle(config.content, config.date, language)
-  const props: ProfiledBoxProps = {
-    imgUrl: imageUrl({
-      id: config.image,
-      scale: 'block(315, 215)',
-      format: 'jpg',
-    }),
-    imageAltText: getImageAlt(config.image) ?? ' ',
-    imagePlacement: config.cardOrientation == 'horizontal' ? 'left' : 'top',
-    href: getLinkTargetUrl(urlContentSelector),
-    subTitle,
-    title,
-    preambleText: config.preamble,
-    titleSize: getTitleSize(title),
-    ariaLabel: getProfiledCardAriaLabel(subTitle),
-  }
-
-  return r4xpRender('site/parts/profiledBox/profiledBox', props, req, {
+  return r4xpRender('site/parts/profiledBox/profiledBox', parseProfiledBoxProps(config, language), req, {
     id: id,
     body: body,
     hydrate: false,
   })
 }
 
-function getSubtitle(content: string | undefined, date: string | undefined, language: string): string {
+function getSubtitleFromConfig(content: string | undefined, date: string | undefined, language: string): string {
   if (content && date) {
     return content + ' / ' + (formatDate(date, 'PPP', language) as string).toLowerCase()
   } else if (content) {
@@ -87,4 +76,39 @@ function getTitleSize(title: string): string {
     titleSize = 'xl'
   }
   return titleSize
+}
+
+function parseProfiledBoxProps(config: ProfiledBoxPartConfig, language: string): ProfiledBoxProps {
+  const urlContentSelector: ProfiledBoxPartConfig['urlContentSelector'] = config.urlContentSelector
+  const linkTargetXPContent = getLinkTargetXPContent(config.urlContentSelector)
+
+  const title = config.title ?? linkTargetXPContent?.displayName ?? ''
+  const subTitle =
+    config.content || config.date
+      ? getSubtitleFromConfig(config.content, config.date, language) // TODO: If either config.content or config.date is empty, what should be returned?
+      : (getSubTitle(linkTargetXPContent as Content<Article>, language) ?? '')
+  const imageDimensions = {
+    scale: 'block(315, 215)' as ImageUrlParams['scale'],
+    format: 'jpg',
+    placeholderWidth: 315,
+    placeholderHeight: 215,
+  }
+  const { imageSrc, imageAlt } = getXPContentImage(linkTargetXPContent as Content<Article>, imageDimensions)
+  return {
+    imgUrl: config.image
+      ? imageUrl({
+          id: config.image,
+          scale: imageDimensions.scale,
+          format: imageDimensions.format,
+        })
+      : (imageSrc ?? ''),
+    imageAltText: config.image ? getImageAlt(config.image) : (imageAlt ?? ''),
+    imagePlacement: config.cardOrientation == 'horizontal' ? 'left' : 'top',
+    href: getLinkTargetUrl(urlContentSelector),
+    subTitle,
+    title,
+    preambleText: config.preamble ?? (linkTargetXPContent?.data?.ingress as string) ?? '',
+    titleSize: getTitleSize(title),
+    ariaLabel: getProfiledCardAriaLabel(subTitle),
+  }
 }

--- a/src/main/resources/site/parts/profiledBox/profiledBox.ts
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.ts
@@ -4,12 +4,11 @@ import {
   getLinkTargetXPContent,
   getProfiledCardAriaLabel,
   getSubTitle,
-  getXPContentImage,
   randomUnsafeString,
 } from '/lib/ssb/utils/utils'
 import { render as r4xpRender } from '/lib/enonic/react4xp'
 import { formatDate } from '/lib/ssb/utils/dateUtils'
-import { imageUrl, getImageAlt } from '/lib/ssb/utils/imageUtils'
+import { imageUrl, getImageAlt, getXPContentImage } from '/lib/ssb/utils/imageUtils'
 
 import { renderError } from '/lib/ssb/error/error'
 import { type ProfiledBoxProps } from '/lib/types/partTypes/profiledBox'

--- a/src/main/resources/site/parts/profiledBox/profiledBox.xml
+++ b/src/main/resources/site/parts/profiledBox/profiledBox.xml
@@ -13,7 +13,7 @@
         </input>
         <input name="image" type="ImageSelector">
             <label>Bilde</label>
-            <occurrences minimum="1" maximum="1"/>
+            <occurrences minimum="0" maximum="1"/>
             <config>
                 <allowPath>${site}</allowPath>
             </config>
@@ -21,22 +21,18 @@
         <input name="content" type="TextLine">
             <label>Innhold</label>
             <occurrences minimum="0" maximum="1"/>
-            <default>Artikkel</default>
         </input>
         <input name="date" type="Date">
             <label>Dato</label>
             <occurrences minimum="0" maximum="1"/>
-            <default>now</default>
         </input>
         <input name="title" type="TextLine">
             <label>Tittel</label>
-            <occurrences minimum="1" maximum="1"/>
-            <default>Her kommer tittelen</default>
+            <occurrences minimum="0" maximum="1"/>
         </input>
         <input name="preamble" type="TextArea">
             <label>Ingress</label>
-            <occurrences minimum="1" maximum="1"/>
-            <default>Her kommer ingress</default>
+            <occurrences minimum="0" maximum="1"/>
         </input>
         <mixin name="linkTarget" />
     </form>

--- a/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
+++ b/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
@@ -11,7 +11,7 @@ import {
   type VariantInListing,
 } from '/lib/ssb/dashboard/statreg/types'
 import { imageUrl, getImageAlt } from '/lib/ssb/utils/imageUtils'
-import { getProfiledCardAriaLabel } from '/lib/ssb/utils/utils'
+import { getProfiledCardAriaLabel, getSubTitle } from '/lib/ssb/utils/utils'
 
 import { renderError } from '/lib/ssb/error/error'
 import * as util from '/lib/util'
@@ -108,7 +108,7 @@ function renderPart(req: XP.Request, relatedArticles: RelatedArticles['relatedAr
                 imageAlt = getImageAlt(image) ? getImageAlt(image) : ''
               }
 
-              const subTitle = getSubTitle(articleContent, phrases, language) ?? ''
+              const subTitle = getSubTitle(articleContent, language) ?? ''
               return {
                 title: articleContent.displayName,
                 subTitle,
@@ -163,25 +163,6 @@ function renderPart(req: XP.Request, relatedArticles: RelatedArticles['relatedAr
       body: body,
     }
   )
-}
-
-function getSubTitle(articleContent: Content<Article> | null, phrases: Phrases, language: string): string | undefined {
-  if (articleContent) {
-    let type = ''
-    if (articleContent.type === `${app.name}:article`) {
-      type = phrases.articleName
-    }
-    let prettyDate: string | undefined = ''
-    if (articleContent.data?.showModifiedDate?.dateOption?.modifiedDate) {
-      prettyDate = formatDate(articleContent.data.showModifiedDate.dateOption.modifiedDate, 'PPP', language)
-    } else if (articleContent.publish?.from) {
-      prettyDate = formatDate(articleContent.publish.from, 'PPP', language)
-    } else {
-      prettyDate = formatDate(articleContent.createdTime, 'PPP', language)
-    }
-    return `${type ? `${type} / ` : ''}${prettyDate as string}`
-  }
-  return
 }
 
 function addDsArticle(

--- a/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
+++ b/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
@@ -10,7 +10,7 @@ import {
   type StatisticInListing,
   type VariantInListing,
 } from '/lib/ssb/dashboard/statreg/types'
-import { imageUrl, getImageAlt, getXPContentImage } from '/lib/ssb/utils/imageUtils'
+import { imageUrl, getImageAlt, getImageFromContent } from '/lib/ssb/utils/imageUtils'
 import { getProfiledCardAriaLabel, getSubtitleForContent } from '/lib/ssb/utils/utils'
 
 import { renderError } from '/lib/ssb/error/error'
@@ -98,7 +98,7 @@ function renderPart(req: XP.Request, relatedArticles: RelatedArticles['relatedAr
                 placeholderWidth: imageWidth,
                 placeholderHeight: imageHeight,
               }
-              const { imageSrc, imageAlt } = getXPContentImage(articleContent, imageDimensions)
+              const { imageSrc, imageAlt } = getImageFromContent(articleContent, imageDimensions)
 
               const subTitle = getSubtitleForContent(articleContent, language) ?? ''
               return {

--- a/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
+++ b/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
@@ -94,7 +94,6 @@ function renderPart(req: XP.Request, relatedArticles: RelatedArticles['relatedAr
               const imageHeight = 180
               const imageDimensions = {
                 scale: `block(${imageWidth}, ${imageHeight})` as ImageUrlParams['scale'], // 16:9
-                format: 'jpg',
                 placeholderWidth: imageWidth,
                 placeholderHeight: imageHeight,
               }

--- a/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
+++ b/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
@@ -10,8 +10,8 @@ import {
   type StatisticInListing,
   type VariantInListing,
 } from '/lib/ssb/dashboard/statreg/types'
-import { imageUrl, getImageAlt } from '/lib/ssb/utils/imageUtils'
-import { getProfiledCardAriaLabel, getSubTitle, getXPContentImage } from '/lib/ssb/utils/utils'
+import { imageUrl, getImageAlt, getXPContentImage } from '/lib/ssb/utils/imageUtils'
+import { getProfiledCardAriaLabel, getSubTitle } from '/lib/ssb/utils/utils'
 
 import { renderError } from '/lib/ssb/error/error'
 import * as util from '/lib/util'

--- a/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
+++ b/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
@@ -11,7 +11,7 @@ import {
   type VariantInListing,
 } from '/lib/ssb/dashboard/statreg/types'
 import { imageUrl, getImageAlt, getXPContentImage } from '/lib/ssb/utils/imageUtils'
-import { getProfiledCardAriaLabel, getSubTitle } from '/lib/ssb/utils/utils'
+import { getProfiledCardAriaLabel, getSubtitleForContent } from '/lib/ssb/utils/utils'
 
 import { renderError } from '/lib/ssb/error/error'
 import * as util from '/lib/util'
@@ -100,7 +100,7 @@ function renderPart(req: XP.Request, relatedArticles: RelatedArticles['relatedAr
               }
               const { imageSrc, imageAlt } = getXPContentImage(articleContent, imageDimensions)
 
-              const subTitle = getSubTitle(articleContent, language) ?? ''
+              const subTitle = getSubtitleForContent(articleContent, language) ?? ''
               return {
                 title: articleContent.displayName,
                 subTitle,

--- a/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
+++ b/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
@@ -1,5 +1,5 @@
 import { type Content, get as getContentByKey, query } from '/lib/xp/content'
-import { getContent, pageUrl, imagePlaceholder } from '/lib/xp/portal'
+import { getContent, type ImageUrlParams, pageUrl } from '/lib/xp/portal'
 import { render } from '/lib/thymeleaf'
 import { type Phrases } from '/lib/types/language'
 import { render as r4xpRender } from '/lib/enonic/react4xp'
@@ -11,7 +11,7 @@ import {
   type VariantInListing,
 } from '/lib/ssb/dashboard/statreg/types'
 import { imageUrl, getImageAlt } from '/lib/ssb/utils/imageUtils'
-import { getProfiledCardAriaLabel, getSubTitle } from '/lib/ssb/utils/utils'
+import { getProfiledCardAriaLabel, getSubTitle, getXPContentImage } from '/lib/ssb/utils/utils'
 
 import { renderError } from '/lib/ssb/error/error'
 import * as util from '/lib/util'
@@ -90,24 +90,13 @@ function renderPart(req: XP.Request, relatedArticles: RelatedArticles['relatedAr
                 return undefined
               }
 
-              let imageSrc: string | undefined
-              let imageAlt: string | undefined = ''
-
-              if (!articleContent.x['com-enonic-app-metafields']?.['meta-data']?.seoImage) {
-                imageSrc = imagePlaceholder({
-                  width: 320,
-                  height: 180,
-                })
-              } else {
-                const image: string = articleContent.x['com-enonic-app-metafields']?.['meta-data']?.seoImage
-                imageSrc = imageUrl({
-                  id: image,
-                  scale: 'block(320, 180)', // 16:9
-                  format: 'jpg',
-                })
-                imageAlt = getImageAlt(image) ? getImageAlt(image) : ''
+              const imageDimensions = {
+                scale: 'block(320, 180)' as ImageUrlParams['scale'], // 16:9
+                format: 'jpg',
+                placeholderWidth: 320,
+                placeholderHeight: 180,
               }
-
+              const { imageSrc, imageAlt } = getXPContentImage(articleContent, imageDimensions)
               const subTitle = getSubTitle(articleContent, language) ?? ''
               return {
                 title: articleContent.displayName,

--- a/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
+++ b/src/main/resources/site/parts/relatedArticles/relatedArticles.ts
@@ -90,13 +90,16 @@ function renderPart(req: XP.Request, relatedArticles: RelatedArticles['relatedAr
                 return undefined
               }
 
+              const imageWidth = 320
+              const imageHeight = 180
               const imageDimensions = {
-                scale: 'block(320, 180)' as ImageUrlParams['scale'], // 16:9
+                scale: `block(${imageWidth}, ${imageHeight})` as ImageUrlParams['scale'], // 16:9
                 format: 'jpg',
-                placeholderWidth: 320,
-                placeholderHeight: 180,
+                placeholderWidth: imageWidth,
+                placeholderHeight: imageHeight,
               }
               const { imageSrc, imageAlt } = getXPContentImage(articleContent, imageDimensions)
+
               const subTitle = getSubTitle(articleContent, language) ?? ''
               return {
                 title: articleContent.displayName,

--- a/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
+++ b/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
@@ -13,7 +13,7 @@ import {
   type RelatedFactPageProps,
   type RelatedFactPages,
 } from '/lib/types/partTypes/relatedFactPage'
-import { getXPContentImage } from '/lib/ssb/utils/imageUtils'
+import { getImageFromContent } from '/lib/ssb/utils/imageUtils'
 import { type Article, type ContentList } from '/site/content-types'
 
 export function get(req: XP.Request): XP.Response {
@@ -178,7 +178,7 @@ export function parseRelatedFactPageData(
 function parseRelatedContent(relatedContent: RelatedFactPage): RelatedFactPageContent {
   const imageWidth = 380
   const imageHeight = 400
-  const { imageSrc: image, imageAlt } = getXPContentImage(relatedContent, {
+  const { imageSrc: image, imageAlt } = getImageFromContent(relatedContent, {
     scale: `block(${imageWidth}, ${imageHeight})` as ImageUrlParams['scale'],
     format: 'jpg',
     placeholderWidth: imageWidth,

--- a/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
+++ b/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
@@ -180,7 +180,6 @@ function parseRelatedContent(relatedContent: RelatedFactPage): RelatedFactPageCo
   const imageHeight = 400
   const { imageSrc: image, imageAlt } = getImageFromContent(relatedContent, {
     scale: `block(${imageWidth}, ${imageHeight})` as ImageUrlParams['scale'],
-    format: 'jpg',
     placeholderWidth: imageWidth,
     placeholderHeight: imageHeight,
   })

--- a/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
+++ b/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
@@ -176,11 +176,13 @@ export function parseRelatedFactPageData(
 }
 
 function parseRelatedContent(relatedContent: RelatedFactPage): RelatedFactPageContent {
+  const imageWidth = 380
+  const imageHeight = 400
   const { imageSrc: image, imageAlt } = getXPContentImage(relatedContent, {
-    scale: 'block(380, 400)' as ImageUrlParams['scale'],
+    scale: `block(${imageWidth}, ${imageHeight})` as ImageUrlParams['scale'],
     format: 'jpg',
-    placeholderWidth: 380,
-    placeholderHeight: 400,
+    placeholderWidth: imageWidth,
+    placeholderHeight: imageHeight,
   })
 
   return {

--- a/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
+++ b/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
@@ -1,8 +1,7 @@
 import { get as getContentByKey, query, type Content } from '/lib/xp/content'
-import { imagePlaceholder, getComponent, getContent, pageUrl, serviceUrl } from '/lib/xp/portal'
+import { getComponent, getContent, pageUrl, serviceUrl, type ImageUrlParams } from '/lib/xp/portal'
 import { render } from '/lib/enonic/react4xp'
 import { type Phrases } from '/lib/types/language'
-import { imageUrl, getImageAlt } from '/lib/ssb/utils/imageUtils'
 
 import { renderError } from '/lib/ssb/error/error'
 import { getPhrases } from '/lib/ssb/utils/language'
@@ -14,6 +13,7 @@ import {
   type RelatedFactPageProps,
   type RelatedFactPages,
 } from '/lib/types/partTypes/relatedFactPage'
+import { getXPContentImage } from '/lib/ssb/utils/utils'
 import { type Article, type ContentList } from '/site/content-types'
 
 export function get(req: XP.Request): XP.Response {
@@ -176,30 +176,19 @@ export function parseRelatedFactPageData(
 }
 
 function parseRelatedContent(relatedContent: RelatedFactPage): RelatedFactPageContent {
-  let imageId: string | undefined
-  let image: string | undefined
-  let imageAlt = ''
-  if (relatedContent.x['com-enonic-app-metafields']?.['meta-data']?.seoImage) {
-    imageId = relatedContent.x['com-enonic-app-metafields']?.['meta-data']?.seoImage
-    imageAlt = getImageAlt(imageId) ?? ''
-    image = imageUrl({
-      id: imageId,
-      scale: 'block(380, 400)',
-      format: 'jpg',
-    })
-  } else {
-    image = imagePlaceholder({
-      width: 380,
-      height: 400,
-    })
-  }
+  const { imageSrc: image, imageAlt } = getXPContentImage(relatedContent, {
+    scale: 'block(380, 400)' as ImageUrlParams['scale'],
+    format: 'jpg',
+    placeholderWidth: 380,
+    placeholderHeight: 400,
+  })
 
   return {
     link: pageUrl({
       id: relatedContent._id,
     }),
     image,
-    imageAlt,
+    imageAlt: imageAlt as string,
     title: relatedContent.displayName,
   }
 }

--- a/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
+++ b/src/main/resources/site/parts/relatedFactPage/relatedFactPage.ts
@@ -13,7 +13,7 @@ import {
   type RelatedFactPageProps,
   type RelatedFactPages,
 } from '/lib/types/partTypes/relatedFactPage'
-import { getXPContentImage } from '/lib/ssb/utils/utils'
+import { getXPContentImage } from '/lib/ssb/utils/imageUtils'
 import { type Article, type ContentList } from '/site/content-types'
 
 export function get(req: XP.Request): XP.Response {


### PR DESCRIPTION
# Pull Request

## Description
* Fetch XP Content data for Editorial Cards part
* Move reusable functions for generating subtitle, urls, and images to utils
* Refactor Editorial Cards, Related Articles, Related Fact Page and Article Archive parts; uses previously mentioned util functions

Link to ticket: MIM-2058

### Branch Deployment to NAIS!
[🗄️ Link to branch admin interface!](https://ssbno-mim-2058.intern.test.ssb.no/admin)
[📰 Front page can be found here!](https://ssbno-mim-2058.intern.test.ssb.no/)