### PR TITLE
feat: add content rendering to markdown part [MIM-2345]

### DIFF
--- a/src/main/resources/lib/ssb/utils/markdownUtils.ts
+++ b/src/main/resources/lib/ssb/utils/markdownUtils.ts
@@ -14,3 +14,9 @@ export function getMarkdownNode(nodeId: string, conn?: RepoConnection) {
   }
   return conn.get(nodeId)
 }
+
+export function getMarkdownText(nodeId: string): string {
+  const node = nodeId ? getMarkdownNode(nodeId) : null
+  const markdownText = node?.markdown
+  return typeof markdownText == 'string' ? markdownText : ''
+}

--- a/src/main/resources/lib/ssb/utils/markdownUtils.ts
+++ b/src/main/resources/lib/ssb/utils/markdownUtils.ts
@@ -16,7 +16,7 @@ export function getMarkdownNode(nodeId: string, conn?: RepoConnection) {
 }
 
 export function getMarkdownText(nodeId: string): string {
-  const node = nodeId ? getMarkdownNode(nodeId) : null
+  const node = getMarkdownNode(nodeId)
   const markdownText = node?.markdown
   return typeof markdownText == 'string' ? markdownText : ''
 }

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -5,15 +5,8 @@ import { render as renderMarkdown } from '/lib/markdown'
 
 export function get(req: XP.Request): XP.Response {
   const component = getComponent<XP.PartComponent.Markdown>()
-  const markdownContent = component?.config.markdownContent
 
-  let markdownText
-  if (markdownContent?._selected == 'fromNode') {
-    const nodeId = markdownContent?.fromNode.nodeId ?? ''
-    markdownText = getMarkdownText(nodeId)
-  } else {
-    markdownText = markdownContent?.fromText.text
-  }
+  const markdownText = component ? getMarkdownTextFromComponent(component) : ''
 
   const props = {
     markdownRendered: renderMarkdown(markdownText),
@@ -22,4 +15,14 @@ export function get(req: XP.Request): XP.Response {
   return render(component, props, req, {
     body: '<section class="xp-part"></section>',
   })
+}
+
+function getMarkdownTextFromComponent(component: XP.PartComponent.Markdown): string {
+  const optionSet = component?.config.markdownContent
+  if (optionSet?._selected == 'fromNode') {
+    const nodeId = optionSet?.fromNode.nodeId ?? ''
+    return getMarkdownText(nodeId)
+  } else {
+    return optionSet?.fromText.text ?? ''
+  }
 }

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -1,5 +1,5 @@
 import { getComponent } from '/lib/xp/portal'
-import { getMarkdownNode } from '/lib/ssb/utils/markdownUtils'
+import { getMarkdownText } from '/lib/ssb/utils/markdownUtils'
 import { render } from '/lib/enonic/react4xp'
 import { render as renderMarkdown } from '/lib/markdown'
 
@@ -10,8 +10,7 @@ export function get(req: XP.Request): XP.Response {
   let markdownText
   if (markdownContent?._selected == 'fromNode') {
     const nodeId = markdownContent?.fromNode.nodeId ?? ''
-    const node = nodeId ? getMarkdownNode(nodeId) : null
-    markdownText = node?.markdown
+    markdownText = getMarkdownText(nodeId)
   } else {
     markdownText = markdownContent?.fromText.text
   }

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -18,11 +18,11 @@ export function get(req: XP.Request): XP.Response {
 }
 
 function getMarkdownTextFromComponent(component: XP.PartComponent.Markdown): string {
-  const optionSet = component?.config.markdownContent
-  if (optionSet?._selected == 'fromNode') {
-    const nodeId = optionSet?.fromNode.nodeId ?? ''
-    return getMarkdownText(nodeId)
+  const optionSet = component.config.markdownContent
+  if (optionSet._selected == 'fromNode') {
+    const nodeId = optionSet.fromNode.nodeId ?? ''
+    return nodeId ? getMarkdownText(nodeId) : ''
   } else {
-    return optionSet?.fromText.text ?? ''
+    return optionSet.fromText.text ?? ''
   }
 }

--- a/src/main/resources/site/parts/markdown/markdown.ts
+++ b/src/main/resources/site/parts/markdown/markdown.ts
@@ -1,12 +1,20 @@
-import { getComponent } from '/lib/xp/portal'
+import { getComponent, getContent } from '/lib/xp/portal'
+import { type Content } from '/lib/xp/content'
 import { getMarkdownText } from '/lib/ssb/utils/markdownUtils'
 import { render } from '/lib/enonic/react4xp'
 import { render as renderMarkdown } from '/lib/markdown'
+import { type Markdown } from '/site/content-types'
 
 export function get(req: XP.Request): XP.Response {
+  const content = getContent<Content<Markdown>>()
   const component = getComponent<XP.PartComponent.Markdown>()
 
-  const markdownText = component ? getMarkdownTextFromComponent(component) : ''
+  let markdownText: string = ''
+  if (content?.type == 'mimir:markdown') {
+    markdownText = getMarkdownTextFromContent(content)
+  } else if (component) {
+    markdownText = getMarkdownTextFromComponent(component)
+  }
 
   const props = {
     markdownRendered: renderMarkdown(markdownText),
@@ -25,4 +33,9 @@ function getMarkdownTextFromComponent(component: XP.PartComponent.Markdown): str
   } else {
     return optionSet.fromText.text ?? ''
   }
+}
+
+function getMarkdownTextFromContent(content: Content<Markdown>): string {
+  const nodeId = content.data.nodeId ?? ''
+  return nodeId ? getMarkdownText(nodeId) : ''
 }


### PR DESCRIPTION
Before this PR, the _markdown_ part rendered the markdown text found in the part component of the current context (using [getComponent](https://developer.enonic.com/docs/xp/stable/api/lib-portal#getcomponent) from Portal API). 

In this PR, the _markdown_ part first checks if there is a content of type _markdown_ in the current context (using [getContent](https://developer.enonic.com/docs/xp/stable/api/lib-portal#getcontent) from the Portal API). 
* If yes, it renders the markdown text in the content.
* If no, it renders the markdown text from the part component as before. 

This change makes it possible to define a template for the content type _markdown_ (the _markdown_ part should be included somewhere in the template). The same has been done for the content type _article_ before, which was the guide for this PR.

This completes the goal of creating and sending back previews to the clients of the _postMarkdown_ service, since content created by the service will now have a preview that is rendered correctly (asssuming the existence of a template).

Link to ticket: MIM-2345