### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testOnPr.yml
+++ b/.github/workflows/testOnPr.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Build, Test and Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/statisticsnorway/mimir/security/code-scanning/18](https://github.com/statisticsnorway/mimir/security/code-scanning/18)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions. Since the workflow only checks out code and runs build/test/lint commands, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow, just below the `name:` field and above the `on:` field. This will apply the least privilege principle to all jobs in the workflow. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
