### PR TITLE
fix: Use date-fns lib instead of manually subtracting the dates ourselves for delete expired event log logic [MIM-2376]

### DIFF
--- a/src/main/resources/lib/ssb/cron/eventLog.ts
+++ b/src/main/resources/lib/ssb/cron/eventLog.ts
@@ -60,9 +60,10 @@ export function deleteExpiredEventLogsForQueries(): void {
 
       if (logCount > maxLogsBeforeDeleting) {
         const daysBeforeLogsExpire = 30
+        const expireDate = subDays(new Date(), daysBeforeLogsExpire)
         const toBeDeleted = logs.slice(0, logCount - maxLogsBeforeDeleting).filter((node) => {
           // Even if above 10, keep them if not expired yet
-          return subDays(new Date(node._ts), daysBeforeLogsExpire)
+          return new Date(node._ts) < expireDate
         })
 
         const deletedCount = withConnection(EVENT_LOG_REPO, EVENT_LOG_BRANCH, (conn) => {

--- a/src/main/resources/site/parts/banner/banner.tsx
+++ b/src/main/resources/site/parts/banner/banner.tsx
@@ -52,9 +52,9 @@ function Banner(props: BannerProps) {
               <h1 className='mt-0 pt-0 position-relative' aria-hidden='true'>
                 {factPageTitle}
               </h1>
-              <div className='sr-only' role='heading' aria-level='1'>
+              <h1 className='sr-only' role='heading'>
                 {fullFactPageTitle}
-              </div>
+              </h1>
             </div>
           )}
           {selectedPageType === 'general' && pageType !== 'municipality' && (

--- a/src/main/resources/site/parts/banner/banner.tsx
+++ b/src/main/resources/site/parts/banner/banner.tsx
@@ -52,9 +52,9 @@ function Banner(props: BannerProps) {
               <h1 className='mt-0 pt-0 position-relative' aria-hidden='true'>
                 {factPageTitle}
               </h1>
-              <h1 className='sr-only' role='heading'>
+              <div className='sr-only' role='heading' aria-level='1'>
                 {fullFactPageTitle}
-              </h1>
+              </div>
             </div>
           )}
           {selectedPageType === 'general' && pageType !== 'municipality' && (


### PR DESCRIPTION
# Pull Request

## Description
- Use date-fns lib instead of manually subtracting the dates ourselves for delete expired event log logic

Link to ticket: MIM-2376