### PR TITLE
fix(banner): prevent image distortion in Safari [MIM-2503]

### DIFF
--- a/src/main/resources/assets/styles/_banner.scss
+++ b/src/main/resources/assets/styles/_banner.scss
@@ -17,10 +17,12 @@
     overflow: hidden;
     height: 100%;
     width: 100%;
+
     img {
       display: block;
       height: auto;
       width: auto;
+      object-fit: cover
     }
 
     @include media-breakpoint-down(md) {
@@ -121,6 +123,7 @@
       min-height: 182px;
       padding-right: 10px;
       padding-left: 10px;
+
       h1 {
         font-size: 36px;
       }

--- a/src/main/resources/assets/styles/_banner.scss
+++ b/src/main/resources/assets/styles/_banner.scss
@@ -22,7 +22,7 @@
       display: block;
       height: auto;
       width: auto;
-      object-fit: cover
+      object-fit: cover;
     }
 
     @include media-breakpoint-down(md) {


### PR DESCRIPTION
# Pull Request

## Description
Fixes an issue where banner images could be distorted in Safari due to flex layout and auto image sizing.  
Using `object-fit: cover` ensures consistent, non-distorted rendering across browsers.


Link to ticket: MIM-2503

### Branch Deployment to NAIS!
[🗄️ Link to branch admin interface!](https://ssbno-mim-2503.intern.test.ssb.no/admin)
[📰 Front page can be found here!](https://ssbno-mim-2503.intern.test.ssb.no/)