### PR TITLE
fix: Use new config for old statbank url [MIM-2530]

### DIFF
--- a/src/main/resources/lib/ssb/dataset/statbankSaved/statbankSaved.ts
+++ b/src/main/resources/lib/ssb/dataset/statbankSaved/statbankSaved.ts
@@ -21,9 +21,9 @@ export function fetchStatbankSavedData(content: Content<DataSource>): object | n
     const format = '.html5_table'
     const basePath = '/sq/'
     const baseUrl: string =
-      app.config && app.config['ssb.statbankweb.baseUrl']
-        ? app.config['ssb.statbankweb.baseUrl']
-        : 'https://www.ssb.no/statbank'
+      app.config && app.config['ssb.statbankweb.oldBaseUrl']
+        ? app.config['ssb.statbankweb.oldBaseUrl']
+        : 'https://www.ssb.no/statbank1'
     const dataSource: DataSource['dataSource'] = content.data.dataSource
     let url: string | null = null
     if (


### PR DESCRIPTION
this is a workaround for the new statbank not supporting the old syntax for saved queries, more permanent fix is incoming. 

Link to ticket: MIM-2530