### PR TITLE
fix: Fixed correct table header override in highcharts [MIM-2562]

### DIFF
--- a/src/main/resources/site/parts/highchart/Highchart.tsx
+++ b/src/main/resources/site/parts/highchart/Highchart.tsx
@@ -346,7 +346,7 @@ function Highchart(props: HighchartsReactProps) {
         ...highchartConfig,
         lang: {
           ...lang,
-          categoryHeader: xAxisOptions.title?.text ?? 'Category',
+          exportData: { categoryHeader: xAxisOptions.title?.text ? xAxisOptions.title?.text : 'Category' },
         },
         chart: {
           ...highchartConfig.chart,


### PR DESCRIPTION
* Moved categoryHeader setting to correct property in highcharts config (under exportdata)
* Made sure table header does not display [object object] if xAxis title is unset

Link to relevant highcharts docs: https://api.highcharts.com/highcharts/lang.exportData.categoryHeader 

Link to ticket: MIM-2562