### PR TITLE
fix: Add function for deleting joblogs for jobs, and ensure it runs daily.  [MIM-2669]

### DIFF
--- a/src/main/resources/lib/ssb/cron/eventLog.ts
+++ b/src/main/resources/lib/ssb/cron/eventLog.ts
@@ -147,5 +147,5 @@ export function deleteExpiredEventLogsForJobs(): void {
     return node
   })
 
-  cronJobLog(`Ferdit å slette gamle eventlogs for Jobs. Antall slettet: ${totalExpiredLogsDeleted}`)
+  cronJobLog(`Ferdig å slette gamle eventlogs for Jobs. Antall slettet: ${totalExpiredLogsDeleted}`)
 }

--- a/src/main/resources/lib/ssb/cron/eventLog.ts
+++ b/src/main/resources/lib/ssb/cron/eventLog.ts
@@ -1,4 +1,4 @@
-import { type Node } from '/lib/xp/node'
+import { NodeQueryResult, type Node } from '/lib/xp/node'
 import { sleep } from '/lib/xp/task'
 import { JobEventNode, startJobLog, updateJobLog, JOB_STATUS_COMPLETE } from '/lib/ssb/repo/job'
 
@@ -15,6 +15,7 @@ type DeletedCount = { contentId: string; deletedCount: number }
 
 export function deleteExpiredEventLogsForQueries(): void {
   cronJobLog('Deleting expired event logs for queries')
+
   const job: JobEventNode = startJobLog('Delete expired event logs for queries')
   const path = '/queries'
   const maxLogsBeforeDeleting = 10 // Have at least 10 logs left for each query to keep its log history
@@ -100,4 +101,55 @@ export function deleteExpiredEventLogsForQueries(): void {
   })
 
   cronJobLog(`Delete expired logs for queries complete. Total expired logs deleted: ${totalExpiredLogsDeleted}`)
+}
+
+export function deleteExpiredEventLogsForJobs(): void {
+  cronJobLog('Deleting expired event logs for jobs')
+
+  const job: JobEventNode = startJobLog('Delete expired event logs for jobs')
+  const path = '/jobs'
+
+  const deleteResult: DeletedCount[] = []
+  let totalExpiredLogsDeleted = 0
+  let total = 999999999
+
+  const count = 1000 // Delete 1000 contents at a time
+  const daysBeforeLogsExpire = 700
+
+  const cutoff = subDays(new Date(), daysBeforeLogsExpire)
+
+  while (total > 0) {
+    sleep(1000)
+    const resultsToBeDeleted: NodeQueryResult = queryNodes(EVENT_LOG_REPO, EVENT_LOG_BRANCH, {
+      query: `_parentPath = "${path}" AND _ts < "${cutoff.toISOString()}" `,
+      start: 0,
+      count,
+    })
+
+    const deletedCount = withConnection(EVENT_LOG_REPO, EVENT_LOG_BRANCH, (conn) => {
+      if (resultsToBeDeleted.count === 0) return 0
+
+      return conn.delete(resultsToBeDeleted.hits.map((n) => n.id)).length
+    })
+
+    total = resultsToBeDeleted.total
+    totalExpiredLogsDeleted += deletedCount
+  }
+
+  log.info(`Finished deleting joblogs for jobs, removed ${totalExpiredLogsDeleted} old logs!`)
+
+  updateJobLog(job._id, (node) => {
+    node.data = {
+      ...node.data,
+      refreshDataResult: deleteResult,
+      status: JOB_STATUS_COMPLETE,
+      message:
+        totalExpiredLogsDeleted == 0
+          ? 'Ingen utdaterte event logs ble slettet'
+          : `Slettet ${totalExpiredLogsDeleted} utdaterte event logs`,
+    }
+    return node
+  })
+
+  cronJobLog(`Delete expired logs for jobs complete. Total expired logs deleted: ${totalExpiredLogsDeleted}`)
 }

--- a/src/main/resources/lib/ssb/cron/eventLog.ts
+++ b/src/main/resources/lib/ssb/cron/eventLog.ts
@@ -14,9 +14,9 @@ import { subDays } from '/lib/vendor/dateFns'
 type DeletedCount = { contentId: string; deletedCount: number }
 
 export function deleteExpiredEventLogsForQueries(): void {
-  cronJobLog('Deleting expired event logs for queries')
+  cronJobLog('Sletter utdaterte event logs for queries')
 
-  const job: JobEventNode = startJobLog('Delete expired event logs for queries')
+  const job: JobEventNode = startJobLog('Sletter utdaterte event logs for queries')
   const path = '/queries'
   const maxLogsBeforeDeleting = 10 // Have at least 10 logs left for each query to keep its log history
 
@@ -100,7 +100,7 @@ export function deleteExpiredEventLogsForQueries(): void {
     return node
   })
 
-  cronJobLog(`Delete expired logs for queries complete. Total expired logs deleted: ${totalExpiredLogsDeleted}`)
+  cronJobLog(`Ferdig med sletting av utdaterte event logs. Totalt antall logger slettet: ${totalExpiredLogsDeleted}`)
 }
 
 export function deleteExpiredEventLogsForJobs(): void {

--- a/src/main/resources/lib/ssb/cron/eventLog.ts
+++ b/src/main/resources/lib/ssb/cron/eventLog.ts
@@ -104,17 +104,16 @@ export function deleteExpiredEventLogsForQueries(): void {
 }
 
 export function deleteExpiredEventLogsForJobs(): void {
-  cronJobLog('Deleting expired event logs for jobs')
+  cronJobLog('Sletter gamle eventlog for Jobs')
 
-  const job: JobEventNode = startJobLog('Delete expired event logs for jobs')
+  const job: JobEventNode = startJobLog('Sletter gamle eventlog for Jobs')
   const path = '/jobs'
 
-  const deleteResult: DeletedCount[] = []
   let totalExpiredLogsDeleted = 0
   let total = 999999999
 
   const count = 1000 // Delete 1000 contents at a time
-  const daysBeforeLogsExpire = 700
+  const daysBeforeLogsExpire = 90
 
   const cutoff = subDays(new Date(), daysBeforeLogsExpire)
 
@@ -136,20 +135,17 @@ export function deleteExpiredEventLogsForJobs(): void {
     totalExpiredLogsDeleted += deletedCount
   }
 
-  log.info(`Finished deleting joblogs for jobs, removed ${totalExpiredLogsDeleted} old logs!`)
-
   updateJobLog(job._id, (node) => {
     node.data = {
       ...node.data,
-      refreshDataResult: deleteResult,
       status: JOB_STATUS_COMPLETE,
       message:
         totalExpiredLogsDeleted == 0
-          ? 'Ingen utdaterte event logs ble slettet'
-          : `Slettet ${totalExpiredLogsDeleted} utdaterte event logs`,
+          ? 'Ingen utdaterte job logs ble slettet'
+          : `Slettet ${totalExpiredLogsDeleted} utdaterte job logs`,
     }
     return node
   })
 
-  cronJobLog(`Delete expired logs for jobs complete. Total expired logs deleted: ${totalExpiredLogsDeleted}`)
+  cronJobLog(`Ferdit å slette gamle eventlogs for Jobs. Antall slettet: ${totalExpiredLogsDeleted}`)
 }

--- a/src/main/resources/main.es6
+++ b/src/main/resources/main.es6
@@ -64,7 +64,7 @@ try {
           enabled: false,
         },
         {
-          feature: 'delete-joblog-jobs',
+          feature: 'delete-joblog-cron',
           enabled: false,
         },
       ],

--- a/src/main/resources/main.es6
+++ b/src/main/resources/main.es6
@@ -63,6 +63,10 @@ try {
           feature: 'use-anniversary-logo',
           enabled: false,
         },
+        {
+          feature: 'delete-joblog-jobs',
+          enabled: false,
+        },
       ],
     },
   ])

--- a/src/main/resources/tasks/deleteExpiredEventLog/deleteExpiredEventLog.ts
+++ b/src/main/resources/tasks/deleteExpiredEventLog/deleteExpiredEventLog.ts
@@ -5,7 +5,7 @@ export function run(): void {
   log.info(`Run Task: deleteExpiredEventLog ${new Date()}`)
   deleteExpiredEventLogsForQueries()
 
-  if (isEnabled('delete-joblog-jobs', false, 'ssb')) {
+  if (isEnabled('delete-joblog-cron', false, 'ssb')) {
     deleteExpiredEventLogsForJobs()
   }
 }

--- a/src/main/resources/tasks/deleteExpiredEventLog/deleteExpiredEventLog.ts
+++ b/src/main/resources/tasks/deleteExpiredEventLog/deleteExpiredEventLog.ts
@@ -1,7 +1,11 @@
 import { deleteExpiredEventLogsForQueries, deleteExpiredEventLogsForJobs } from '/lib/ssb/cron/eventLog'
+import { isEnabled } from '/lib/featureToggle'
 
 export function run(): void {
   log.info(`Run Task: deleteExpiredEventLog ${new Date()}`)
   deleteExpiredEventLogsForQueries()
-  deleteExpiredEventLogsForJobs()
+
+  if (isEnabled('delete-joblog-jobs', false, 'ssb')) {
+    deleteExpiredEventLogsForJobs()
+  }
 }

--- a/src/main/resources/tasks/deleteExpiredEventLog/deleteExpiredEventLog.ts
+++ b/src/main/resources/tasks/deleteExpiredEventLog/deleteExpiredEventLog.ts
@@ -1,6 +1,7 @@
-import { deleteExpiredEventLogsForQueries } from '/lib/ssb/cron/eventLog'
+import { deleteExpiredEventLogsForQueries, deleteExpiredEventLogsForJobs } from '/lib/ssb/cron/eventLog'
 
 export function run(): void {
   log.info(`Run Task: deleteExpiredEventLog ${new Date()}`)
   deleteExpiredEventLogsForQueries()
+  deleteExpiredEventLogsForJobs()
 }


### PR DESCRIPTION
# Job logs are not being deleted correctly

Some of the job logs need to be deleted separately. This addition should correctly delete these. Function is toggled by feature flag

Link to ticket: MIM-2669