### PR TITLE
chore: rename cookie for consent [MIM-2759]

### DIFF
--- a/src/main/resources/react4xp/_entries/CookieBanner.tsx
+++ b/src/main/resources/react4xp/_entries/CookieBanner.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Button, Link } from '@statisticsnorway/ssb-component-library'
 import { type CookieBannerProps } from '/lib/types/cookieBanner'
 
-const COOKIE_NAME = 'cookie-consent'
+const COOKIE_NAME = 'ssbno-consent'
 const SERVICE_URL = '/_/service/mimir/setCookieConsent'
 const MAX_FETCH_FAILURES = 3
 let failureCount = 0

--- a/src/main/resources/react4xp/_entries/Footer.tsx
+++ b/src/main/resources/react4xp/_entries/Footer.tsx
@@ -165,7 +165,7 @@ const Footer = (props: FooterContent) => {
     try {
       await fetch(`${COOKIE_SERVICE_URL}?value=unidentified`, { credentials: 'include' })
     } catch (e) {
-      console.error('Failed to reset cookie-consent via service', e)
+      console.error('Failed to reset ssbno-consent via service', e)
     }
   }
 

--- a/src/main/resources/services/setCookieConsent/setCookieConsent.ts
+++ b/src/main/resources/services/setCookieConsent/setCookieConsent.ts
@@ -6,7 +6,7 @@ export function get(req: Request): Response {
   if (!value || !['all', 'necessary', 'unidentified'].includes(value)) {
     return {
       status: 400,
-      body: 'Invalid cookie-consent value',
+      body: 'Invalid ssbno-consent value',
     }
   }
 
@@ -15,7 +15,7 @@ export function get(req: Request): Response {
     body: JSON.stringify({ success: true, value }),
     contentType: 'application/json',
     cookies: {
-      'cookie-consent': {
+      'ssbno-consent': {
         value,
         path: '/',
         maxAge: 7776000, // 90 dager

--- a/src/main/resources/site/pages/default/default.ts
+++ b/src/main/resources/site/pages/default/default.ts
@@ -213,7 +213,7 @@ export function get(req: Request): Response {
   }
   const cookies = !isCookieBannerEnabled
     ? {
-        'cookie-consent': {
+        'ssbno-consent': {
           value: '',
           path: '/',
           maxAge: 0,


### PR DESCRIPTION
Første forslag til navn følger samme navngivning som NAV (_navno-consent_). Satt opp teknisk hjørne-sak for å avklare. Edit: avklart før teknisk hjørne.

Lokal testing:

Ny cookiebanner kommer opp når gammel er godkjent:
<img width="1878" height="739" alt="Skjermbilde 2026-05-29 115555" src="https://github.com/user-attachments/assets/73b7857d-e59b-44f3-a8f8-9b2c365f370f" />

Når man godkjenner på nytt:

<img width="915" height="171" alt="Skjermbilde 2026-05-29 115635" src="https://github.com/user-attachments/assets/d1a8faa6-105f-448e-9f7a-e53b6baa693d" />

Gammel cookie vil gå ut på dato og slettes av nettleseren. Bra nok, eller bør vi eksplisitt  slette den? 

Signed-off-by: Olav Landsverk <stud-oll@ssb.no>

Link to ticket: MIM-2759